### PR TITLE
XCTest

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,4 +1,3 @@
 github "krzyzanowskim/CryptoSwift.git" "develop"
 github "Quick/Nimble" ~> 5.1.1
-github "Quick/Quick" ~> 1.0.0
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,4 @@
-github "krzyzanowskim/CryptoSwift" "97f574390810ef7daef551f2bb708890f3655fd8"
-github "anviking/Decodable" "v0.5.1"
 github "JensRavens/Interstellar" "2.0.0"
 github "Quick/Nimble" "v5.1.1"
-github "Quick/Quick" "v1.0.0"
-
+github "anviking/Decodable" "v0.5.1"
+github "krzyzanowskim/CryptoSwift" "83072f7e31498e879f77c62feb08715dfa45acfb"

--- a/Contentful.xcodeproj/project.pbxproj
+++ b/Contentful.xcodeproj/project.pbxproj
@@ -84,7 +84,6 @@
 		ED65CF921E3F6BD7000EBC62 /* Interstellar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED65CF901E3F6BD7000EBC62 /* Interstellar.framework */; };
 		ED65CF971E3F6BF8000EBC62 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED65CF941E3F6BF8000EBC62 /* CryptoSwift.framework */; };
 		ED65CF981E3F6BF8000EBC62 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED65CF951E3F6BF8000EBC62 /* Nimble.framework */; };
-		ED65CF991E3F6BF8000EBC62 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED65CF961E3F6BF8000EBC62 /* Quick.framework */; };
 		ED65CF9B1E3F6C0C000EBC62 /* Interstellar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED65CF9A1E3F6C0C000EBC62 /* Interstellar.framework */; };
 		ED65CF9E1E3F6C2A000EBC62 /* Decodable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED65CF9C1E3F6C2A000EBC62 /* Decodable.framework */; };
 		ED65CF9F1E3F6C2A000EBC62 /* Interstellar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED65CF9D1E3F6C2A000EBC62 /* Interstellar.framework */; };
@@ -141,7 +140,6 @@
 		ED65CF901E3F6BD7000EBC62 /* Interstellar.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Interstellar.framework; path = Carthage/Build/iOS/Interstellar.framework; sourceTree = "<group>"; };
 		ED65CF941E3F6BF8000EBC62 /* CryptoSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoSwift.framework; path = Carthage/Build/iOS/CryptoSwift.framework; sourceTree = "<group>"; };
 		ED65CF951E3F6BF8000EBC62 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
-		ED65CF961E3F6BF8000EBC62 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		ED65CF9A1E3F6C0C000EBC62 /* Interstellar.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Interstellar.framework; path = Carthage/Build/iOS/Interstellar.framework; sourceTree = "<group>"; };
 		ED65CF9C1E3F6C2A000EBC62 /* Decodable.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Decodable.framework; path = Carthage/Build/Mac/Decodable.framework; sourceTree = "<group>"; };
 		ED65CF9D1E3F6C2A000EBC62 /* Interstellar.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Interstellar.framework; path = Carthage/Build/Mac/Interstellar.framework; sourceTree = "<group>"; };
@@ -172,7 +170,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ED65CF991E3F6BF8000EBC62 /* Quick.framework in Frameworks */,
 				ED65CF981E3F6BF8000EBC62 /* Nimble.framework in Frameworks */,
 				ED65CF9B1E3F6C0C000EBC62 /* Interstellar.framework in Frameworks */,
 				A19CA3CF1B836EDD00A0EFCD /* Contentful.framework in Frameworks */,
@@ -339,7 +336,6 @@
 				ED65CF9A1E3F6C0C000EBC62 /* Interstellar.framework */,
 				ED65CF941E3F6BF8000EBC62 /* CryptoSwift.framework */,
 				ED65CF951E3F6BF8000EBC62 /* Nimble.framework */,
-				ED65CF961E3F6BF8000EBC62 /* Quick.framework */,
 			);
 			name = TestFrameworks;
 			sourceTree = "<group>";

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ kill_simulator:
 	killall "Simulator" || true
 
 test: clean clean_simulators
-	xcodebuild -project Contentful.xcodeproj \
-		-scheme Contentful_iOS -destination 'id=$(SIM_ID)' test | xcpretty -c
+	xcodebuild test -project Contentful.xcodeproj \
+		-scheme Contentful_iOS -destination 'id=$(SIM_ID)' OTHER_SWIFT_FLAGS="-warnings-as-errors" | xcpretty -c
 
 setup:
 	bundle install

--- a/Scripts/travis-build-test.sh
+++ b/Scripts/travis-build-test.sh
@@ -10,5 +10,5 @@ rm -rf ${HOME}/Library/Developer/Xcode/DerivedData/*
 # `sysctl -n hw.ncpu` -- fetch number of 'logical' cores in macOS machine
 xcodebuild -jobs `sysctl -n hw.ncpu` test -project Contentful.xcodeproj -scheme Contentful_iOS \
   -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s,OS=9.3" \
-    ONLY_ACTIVE_ARCH=NO CODE_SIGNING_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty -c
+    ONLY_ACTIVE_ARCH=NO CODE_SIGNING_IDENTITY="" CODE_SIGNING_REQUIRED=NO OTHER_SWIFT_FLAGS="-warnings-as-errors" | xcpretty -c
 

--- a/Tests/AssetTests.swift
+++ b/Tests/AssetTests.swift
@@ -7,9 +7,9 @@
 //
 
 @testable import Contentful
+import XCTest
 import CryptoSwift
 import Nimble
-import Quick
 
 func url(_ asset: Asset) -> URL {
     var url = URL(string: "http://example.com")
@@ -17,86 +17,80 @@ func url(_ asset: Asset) -> URL {
     return url!
 }
 
-class AssetTests: ContentfulBaseTests {
+class AssetTests: XCTestCase {
+
+    let client = Client(spaceId: "cfexampleapi", accessToken: "b4c0n73n7fu1")
 
     func md5(_ image: UIImage) -> String {
         return UIImagePNGRepresentation(image)!.md5().toHexString()
     }
 
-    // Linker error with too many levels of closures 😭
-    func testFetchImageFromAsset(_ done: @escaping (Void) -> Void) {
+    // MARK: Tests
+
+    func testFetchSingleAsset() {
+        let expectation = self.expectation(description: "Fetch single asset network expectation")
+
+        self.client.fetchAsset(identifier: "nyancat") { (result) in
+            switch result {
+            case let .success(asset):
+                expect(asset.identifier).to(equal("nyancat"))
+                expect(asset.type).to(equal("Asset"))
+                expect(url(asset).absoluteString).to(equal("https://images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png"))
+            case let .error(error):
+                fail("\(error)")
+            }
+
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
+
+    func testFetchAllAssetsInSpace() {
+        let expectation = self.expectation(description: "Fetch all assets network expectation")
+        self.client.fetchAssets().1.then { assets in
+            expect(assets.items.count).to(equal(4))
+
+            if let asset = (assets.items.filter { $0.identifier == "nyancat" }).first {
+                expect(asset.identifier).to(equal("nyancat"))
+                expect(asset.type).to(equal("Asset"))
+                expect(url(asset).absoluteString).to(equal("https://images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png"))
+            } else {
+                fail("Could not find asset with id 'nyancat'")
+            }
+
+            expectation.fulfill()
+        }.error {
+            fail("\($0)")
+        }
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
+
+    func testFetchImageForAsset() {
+        let expectation = self.expectation(description: "Fetch image from asset network expectation")
 
         self.client.fetchAsset(identifier: "nyancat").1.then { asset in
 
             asset.fetchImage().1.then { image in
                 expect(self.md5(image)).to(equal("94fd9a22b0b6ecab15d91486922b8d7e"))
-                done()
+                expectation.fulfill()
             }
         }.error {
             fail("\($0)")
-            done()
         }
+        waitForExpectations(timeout: 10.0, handler: nil)
     }
 
-    func testNyanCatAssetObject(_ asset: Asset) {
-        expect(asset.identifier).to(equal("nyancat"))
-        expect(asset.type).to(equal("Asset"))
-        expect(url(asset).absoluteString).to(equal("https://images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png"))
-    }
+    func testFilterAssetsByMIMETypeGroup() {
+        let expectation = self.expectation(description: "Fetch image from asset network expectation")
 
-    override func spec() {
-        super.spec()
+        // FIXME: We should have a different test expectation as this mimics the one above
+        self.client.fetchAssets(matching: ["mimetype_group": "image"]).1.then { assets in
 
-        it("can fetch all assets of a space") {
-            waitUntil(timeout: 10) { done in
-                self.client.fetchAssets().1.then {
-                    expect($0.items.count).to(equal(4))
-
-                    if let asset = ($0.items.filter { $0.identifier == "nyancat" }).first {
-                        self.testNyanCatAssetObject(asset)
-                    } else {
-                        fail("Could not find asset with id 'nyancat'")
-                    }
-
-                    done()
-                }.error {
-                    fail("\($0)")
-                    done()
-                }
-            }
+            expect(assets.items.count).to(equal(4))
+            expectation.fulfill()
+        }.error {
+            fail("\($0)")
         }
-
-        it("can fetch a single asset") {
-            waitUntil(timeout: 10) { done in
-                self.client.fetchAsset(identifier: "nyancat") { (result) in
-                    switch result {
-                    case let .success(asset):
-                        self.testNyanCatAssetObject(asset)
-                    case let .error(error):
-                        fail("\(error)")
-                    }
-
-                    done()
-                }
-            }
-        }
-
-        it("can fetch an image from an asset") {
-            waitUntil(timeout: 10) { done in
-                self.testFetchImageFromAsset(done)
-            }
-        }
-
-        it("can filter assets by MIMEType group") {
-            waitUntil { done in
-                self.client.fetchAssets(matching: ["mimetype_group": "image"]).1.then {
-                    expect($0.items.count).to(equal(4))
-                    done()
-                }.error {
-                    fail("\($0)")
-                    done()
-                }
-            }
-        }
+        waitForExpectations(timeout: 10.0, handler: nil)
     }
 }

--- a/Tests/ContentTypeTests.swift
+++ b/Tests/ContentTypeTests.swift
@@ -7,71 +7,79 @@
 //
 
 @testable import Contentful
+import XCTest
 import Nimble
-import Quick
 
-class ContentTypeTests: ContentfulBaseTests {
-    override func spec() {
-        super.spec()
+class ContentTypeTests: XCTestCase {
 
-        it("can fetch a content-type") {
-            waitUntil(timeout: 10) { done in
-                self.client.fetchContentType(identifier: "cat") { (result) in
-                    switch result {
-                    case let .success(type):
-                        expect(type.identifier).to(equal("cat"))
-                        expect(type.type).to(equal("ContentType"))
+    var client: Client!
 
-                        if let field = type.fields.first {
-                            expect(field.disabled).to(equal(false))
-                            expect(field.localized).to(equal(true))
-                            expect(field.required).to(equal(true))
+    override func setUp() {
+        super.setUp()
+        self.client = Client(spaceId: "cfexampleapi", accessToken: "b4c0n73n7fu1")
+    }
 
-                            expect(field.type).to(equal(FieldType.Text))
-                            expect(field.itemType).to(equal(FieldType.None))
-                        } else {
-                            fail()
-                        }
+    func testFetchContentType() {
+        let expectation = self.expectation(description: "Client can fetch a content type")
 
-                        if let field = type.fields.filter({ $0.identifier == "likes" }).first {
-                            expect(field.itemType).to(equal(FieldType.Symbol))
-                        }
+        self.client.fetchContentType(identifier: "cat") { (result) in
 
-                        if let field = type.fields.filter({ $0.identifier == "image" }).first {
-                            expect(field.itemType).to(equal(FieldType.Asset))
-                        }
+            switch result {
+            case let .success(type):
+                expect(type.identifier).to(equal("cat"))
+                expect(type.type).to(equal("ContentType"))
 
-                        let field = type.fields[0]
-                        expect(field.identifier).to(equal("name"))
-                    case let .error(error):
-                        fail("\(error)")
-                    }
+                if let field = type.fields.first {
+                    expect(field.disabled).to(equal(false))
+                    expect(field.localized).to(equal(true))
+                    expect(field.required).to(equal(true))
 
-                    done()
+                    expect(field.type).to(equal(FieldType.Text))
+                    expect(field.itemType).to(equal(FieldType.None))
+                } else {
+                    fail()
                 }
+
+                if let field = type.fields.filter({ $0.identifier == "likes" }).first {
+                    expect(field.itemType).to(equal(FieldType.Symbol))
+                }
+
+                if let field = type.fields.filter({ $0.identifier == "image" }).first {
+                    expect(field.itemType).to(equal(FieldType.Asset))
+                }
+
+                let field = type.fields[0]
+                expect(field.identifier).to(equal("name"))
+            case let .error(error):
+                fail("\(error)")
             }
+            expectation.fulfill()
         }
 
-        it("can fetch all content types of a space") {
-            waitUntil(timeout: 10) { done in
-                self.client.fetchContentTypes { (result) in
-                    switch result {
-                    case let .success(array):
-                        expect(array.total).to(equal(4))
-                        expect(array.limit).to(equal(100))
-                        expect(array.skip).to(equal(0))
-                        expect(array.items.count).to(equal(4))
+        waitForExpectations(timeout: 10, handler: nil)
+    }
 
-                        let _ = array.items.first.flatMap { (type: ContentType) in
-                            expect(type.name).to(equal("City"))
-                        }
-                    case let .error(error):
-                        fail("\(error)")
-                    }
+    func testFetchAllContentTypesInSpace() {
 
-                    done()
+        let expectation = self.expectation(description: "can fetch all content types of a space")
+
+        self.client.fetchContentTypes { result in
+            switch result {
+            case let .success(array):
+                expect(array.total).to(equal(4))
+                expect(array.limit).to(equal(100))
+                expect(array.skip).to(equal(0))
+                expect(array.items.count).to(equal(4))
+
+                let _ = array.items.first.flatMap { (type: ContentType) in
+                    expect(type.name).to(equal("City"))
                 }
+            case let .error(error):
+                fail("\(error)")
             }
+
+            expectation.fulfill()
         }
+        waitForExpectations(timeout: 10, handler: nil)
     }
 }

--- a/Tests/DecodingTests.swift
+++ b/Tests/DecodingTests.swift
@@ -8,11 +8,11 @@
 
 @testable import Contentful
 import Foundation
+import XCTest
 import Nimble
-import Quick
 
+class DecodingTests: XCTestCase {
 
-class DecodingTests: QuickSpec {
     func jsonData(_ fileName: String) -> Any {
         let path = NSString(string: "Data").appendingPathComponent(fileName)
         let bundle = Bundle(for: DecodingTests.self)
@@ -21,91 +21,84 @@ class DecodingTests: QuickSpec {
         return try! JSONSerialization.jsonObject(with: data, options: [])
     }
 
-    override func spec() {
-        describe("Decoding data") {
-            it("can decode assets") {
-                do {
-                    let asset = try Asset.decode(self.jsonData("asset"))
+    func testDecodeAsset() {
+        do {
+            let asset = try Asset.decode(self.jsonData("asset"))
 
 
-                    expect(asset.identifier).to(equal("nyancat"))
-                    expect(asset.type).to(equal("Asset"))
-                    expect(try asset.URL()).to(equal(URL(string: "https://images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png")))
-                } catch _ {
-                    XCTAssert(false, "Asset decoding should not throw an error")
-                }
-            }
+            expect(asset.identifier).to(equal("nyancat"))
+            expect(asset.type).to(equal("Asset"))
+            expect(try asset.URL()).to(equal(URL(string: "https://images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png")))
+        } catch _ {
+            fail("Asset decoding should not throw an error")
+        }
+    }
 
-            it("can decode spaces") {
-                do {
-                    let space = try Space.decode(self.jsonData("space"))
+    func testDecodeSpaces() {
+        do {
+            let space = try Space.decode(self.jsonData("space"))
 
-                    expect(space.identifier).to(equal("cfexampleapi"))
-                    expect(space.name).to(equal("Contentful Example API"))
-                    expect(space.locales.count).to(equal(2))
-                    expect(space.locales[0].name).to(equal("English"))
-                    expect(space.locales[0].code).to(equal("en-US"))
-                    expect(space.locales[0].isDefault).to(equal(true))
-                } catch _ {
-                    XCTAssert(false, "Space decoding should not throw an error")
-                }
+            expect(space.identifier).to(equal("cfexampleapi"))
+            expect(space.name).to(equal("Contentful Example API"))
+            expect(space.locales.count).to(equal(2))
+            expect(space.locales[0].name).to(equal("English"))
+            expect(space.locales[0].code).to(equal("en-US"))
+            expect(space.locales[0].isDefault).to(equal(true))
+        } catch _ {
+            fail("Space decoding should not throw an error")
+        }
+    }
 
-            }
+    func testDecodeLocalizedEntries() {
+        do {
+            var entry = try Entry.decode(self.jsonData("localized"))
 
-            it("can decode localized entries") {
-                do {
-                    var entry = try Entry.decode(self.jsonData("localized"))
+            expect(entry.identifier).to(equal("nyancat"))
+            expect(entry.fields["name"] as? String).to(equal("Nyan Cat"))
 
-                    expect(entry.identifier).to(equal("nyancat"))
-                    expect(entry.fields["name"] as? String).to(equal("Nyan Cat"))
+            entry.locale = "tlh"
 
-                    entry.locale = "tlh"
+            expect(entry.fields["name"] as? String).to(equal("Nyan vIghro'"))
+        } catch _ {
+            fail("Localized Entry decoding should not throw an error")
+        }
+    }
 
-                    expect(entry.fields["name"] as? String).to(equal("Nyan vIghro'"))
-                } catch _ {
-                    XCTAssert(false, "Localized Entry decoding should not throw an error")
+    func testDecodeSyncResponses() {
+        do {
+            let syncSpace = try SyncSpace.decode(self.jsonData("sync"))
 
-                }
-            }
+            expect(syncSpace.assets.count).to(equal(4))
+            expect(syncSpace.entries.count).to(equal(11))
+            expect(syncSpace.syncToken).to(equal("w5ZGw6JFwqZmVcKsE8Kow4grw45QdybCnV_Cg8OASMKpwo1UY8K8bsKFwqJrw7DDhcKnM2RDOVbDt1E-wo7CnDjChMKKGsK1wrzCrBzCqMOpZAwOOcOvCcOAwqHDv0XCiMKaOcOxZA8BJUzDr8K-wo1lNx7DnHE"))
+        } catch _ {
+            fail("Decoding sync responses should not throw an error")
+        }
+    }
 
-            it("can decode sync responses") {
-                do {
-                    let syncSpace = try SyncSpace.decode(self.jsonData("sync"))
+    func testDecodeSyncResponsesWithDeletedAssets() {
+        do {
+            let syncSpace = try SyncSpace.decode(self.jsonData("deleted-asset"))
 
-                    expect(syncSpace.assets.count).to(equal(4))
-                    expect(syncSpace.entries.count).to(equal(11))
-                    expect(syncSpace.syncToken).to(equal("w5ZGw6JFwqZmVcKsE8Kow4grw45QdybCnV_Cg8OASMKpwo1UY8K8bsKFwqJrw7DDhcKnM2RDOVbDt1E-wo7CnDjChMKKGsK1wrzCrBzCqMOpZAwOOcOvCcOAwqHDv0XCiMKaOcOxZA8BJUzDr8K-wo1lNx7DnHE"))
-                } catch _ {
-                    XCTAssert(false, "Decoding sync responses should not throw an error")
-                }
-            }
+            expect(syncSpace.assets.count).to(equal(0))
+            expect(syncSpace.entries.count).to(equal(0))
+            expect(syncSpace.deletedAssets.count).to(equal(1))
+            expect(syncSpace.deletedEntries.count).to(equal(0))
+        } catch _ {
+            fail("Decoding sync responses with deleted Assets should not throw an error")
+        }
+    }
 
-            it("can decode sync responses with deleted assets") {
-                do {
-                    let syncSpace = try SyncSpace.decode(self.jsonData("deleted-asset"))
+    func testDecodeSyncResponsesWithDeletedEntries() {
+        do {
+            let syncSpace = try SyncSpace.decode(self.jsonData("deleted"))
 
-                    expect(syncSpace.assets.count).to(equal(0))
-                    expect(syncSpace.entries.count).to(equal(0))
-                    expect(syncSpace.deletedAssets.count).to(equal(1))
-                    expect(syncSpace.deletedEntries.count).to(equal(0))
-                } catch _ {
-                    XCTAssert(false, "Decoding sync responses with deleted Assets should not throw an error")
-                }
-            }
-
-            it("can decode sync responses with deleted entries") {
-                do {
-                    let syncSpace = try SyncSpace.decode(self.jsonData("deleted"))
-
-                    expect(syncSpace.assets.count).to(equal(0))
-                    expect(syncSpace.entries.count).to(equal(0))
-                    expect(syncSpace.deletedAssets.count).to(equal(0))
-                    expect(syncSpace.deletedEntries.count).to(equal(1))
-                } catch _ {
-                    XCTAssert(false, "Decoding sync responses with deleted Entries should not throw an error")
-
-                }
-            }
+            expect(syncSpace.assets.count).to(equal(0))
+            expect(syncSpace.entries.count).to(equal(0))
+            expect(syncSpace.deletedAssets.count).to(equal(0))
+            expect(syncSpace.deletedEntries.count).to(equal(1))
+        } catch _ {
+            fail("Decoding sync responses with deleted Entries should not throw an error")
         }
     }
 }

--- a/Tests/SyncTests.swift
+++ b/Tests/SyncTests.swift
@@ -7,68 +7,71 @@
 //
 
 @testable import Contentful
+import XCTest
 import Interstellar
 import Nimble
-import Quick
 
-class SyncTests: ContentfulBaseTests {
-    func waitUntilSync(matching: [String: Any], action: @escaping (_ space: SyncSpace) -> ()) {
-        waitUntil { done in
-            self.client.initialSync(matching: matching).1.then {
-                action($0)
-                done()
-            }.error {
-                fail("\($0)")
-                done()
-            }
+class SyncTests: XCTestCase {
+
+    let client = Client(spaceId: "cfexampleapi", accessToken: "b4c0n73n7fu1")
+
+    func waitUntilSync(matching: [String : Any], action: @escaping (_ space: SyncSpace) -> ()) {
+        let expectation = self.expectation(description: "Sync test expecation")
+
+        self.client.initialSync(matching: matching).1.then {
+            action($0)
+            expectation.fulfill()
+        }.error {
+            fail("\($0)")
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
+
+    func testPerformInitialSync() {
+        self.waitUntilSync(matching: [String: Any]()) {
+            expect($0.assets.count).to(equal(4))
+            expect($0.entries.count).to(equal(10))
         }
     }
 
-    override func spec() {
-        super.spec()
-
-        it("can perform an initial sync for a space") {
-            self.waitUntilSync(matching: [String: Any]()) {
-                expect($0.assets.count).to(equal(4))
-                expect($0.entries.count).to(equal(10))
+    func testPerformSubsequentSync() {
+        let expectation = self.expectation(description: "Subsequent Sync test expecation")
+        self.client.initialSync().1.flatMap { (result: Result<SyncSpace>) -> Observable<Result<SyncSpace>> in
+            switch result {
+            case .success(let space):
+                return space.sync().1
+            case .error(let error):
+                fail("\(error)")
+                return Observable<Result<SyncSpace>>()
             }
+        }.then {
+            expect($0.assets.count).to(equal(4))
+            expect($0.entries.count).to(equal(10))
+
+            expectation.fulfill()
+
+        }.error {
+            fail("\($0)")
+
+            expectation.fulfill()
         }
 
-        it("can perform a subsequent sync for a space") {
-            waitUntil { done in
-                self.client.initialSync().1.flatMap { (result: Result<SyncSpace>) -> Observable<Result<SyncSpace>> in
-                    switch result {
-                    case .success(let space):
-                        return space.sync().1
-                    case .error(let error):
-                        fail("\(error)")
-                        return Observable<Result<SyncSpace>>()
-                    }
-                }.then {
-                    expect($0.assets.count).to(equal(4))
-                    expect($0.entries.count).to(equal(10))
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
 
-                    done()
-                }.error {
-                    fail("\($0)")
-
-                    done()
-                }
-            }
+    func testSyncDataOfSpecificType() {
+        self.waitUntilSync(matching: ["type": "Asset"]) {
+            expect($0.assets.count).to(equal(4))
+            expect($0.entries.count).to(equal(0))
         }
+    }
 
-        it("can sync data of a specific type") {
-            self.waitUntilSync(matching: ["type": "Asset"]) {
-                expect($0.assets.count).to(equal(4))
-                expect($0.entries.count).to(equal(0))
-            }
-        }
-
-        it("can sync entries of a specific content type") {
-            self.waitUntilSync(matching: ["type": "Entry", "content_type": "cat"]) {
-                expect($0.assets.count).to(equal(0))
-                expect($0.entries.count).to(equal(3))
-            }
+    func testSyncEntriesOfContentType() {
+        self.waitUntilSync(matching: ["type": "Entry", "content_type": "cat"]) {
+            expect($0.assets.count).to(equal(0))
+            expect($0.entries.count).to(equal(3))
         }
     }
 }

--- a/Tests/UtilityTests.swift
+++ b/Tests/UtilityTests.swift
@@ -6,29 +6,27 @@
 //  Copyright © 2016 Contentful GmbH. All rights reserved.
 //
 
-import Nimble
-import Quick
-
 @testable import Contentful
+import XCTest
+import Nimble
 
-class UtilityTests: QuickSpec {
+
+class UtilityTests: XCTestCase {
     let original = [ "foo": 1, "bar": 2 ]
     let fallback = [ "moo": 42, "bar": 7 ]
 
-    override func spec() {
-        it("can merge two dictionaries") {
-            let union = self.fallback + self.original
+    func testMergeTwoDictionaries() {
+        let union = self.fallback + self.original
 
-            expect(union).to(equal([ "foo": 1, "bar": 2, "moo": 42 ]))
-            expect(union.count).to(equal(3))
-        }
+        expect(union).to(equal([ "foo": 1, "bar": 2, "moo": 42 ]))
+        expect(union.count).to(equal(3))
+    }
 
-        it("puts the correct values into a merged dictionary") {
-            let union = self.fallback + self.original
+    func testPutsTheCorrectValuesIntoMergedDictionary() {
+        let union = self.fallback + self.original
 
-            expect(union["foo"]).to(equal(1))
-            expect(union["bar"]).to(equal(2))
-            expect(union["moo"]).to(equal(42))
-        }
+        expect(union["foo"]).to(equal(1))
+        expect(union["bar"]).to(equal(2))
+        expect(union["moo"]).to(equal(42))
     }
 }


### PR DESCRIPTION
Use XCTest as testing framework instead of Quick. The main reason for this change is that XCTest is _much_ more tightly integrated with Xcode.
