### PR TITLE
Ensure all declerations have explicit protection level set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) starting from 1.x releases.
 
 ### Merged, but not yet released
-> All recent changes are published
+> ~~All recent changes are published~~
+> Fixed
+> - Ensured all functions and instance members had an explicit protection level set.
 ---
 
 ## Table of contents

--- a/Sources/Contentful/Client.swift
+++ b/Sources/Contentful/Client.swift
@@ -370,7 +370,7 @@ extension Client {
      - Returns: Tuple of the data task and a signal for the `Data` result.
 
      */
-    public func fetchData(for asset: Asset, with imageOptions: [ImageOption] = []) -> Observable<Result<Data>> {
+    @discardableResult public func fetchData(for asset: Asset, with imageOptions: [ImageOption] = []) -> Observable<Result<Data>> {
         do {
             return fetch(url: try asset.url(with: imageOptions)).observable
         } catch let error {
@@ -547,7 +547,7 @@ extension Client {
 
      - Returns: An `Observable` which will be fired when the `SyncSpace` is fully synchronized with Contentful.
      */
-    @discardableResult func nextSync(for syncSpace: SyncSpace,
+    @discardableResult public func nextSync(for syncSpace: SyncSpace,
                                      matching: [String: Any] = [:]) -> Observable<Result<SyncSpace>> {
 
         let observable = Observable<Result<SyncSpace>>()

--- a/Sources/Contentful/ClientConfiguration.swift
+++ b/Sources/Contentful/ClientConfiguration.swift
@@ -8,10 +8,9 @@
 
 import Foundation
 
-enum Defaults {
-    static let cdaHost = "cdn.contentful.com"
-    static let locale = "en-US"
-    static let previewHost = "preview.contentful.com"
+public enum Defaults {
+    public static let cdaHost = "cdn.contentful.com"
+    public static let previewHost = "preview.contentful.com"
 }
 
 /**

--- a/Sources/Contentful/ContentModellable.swift
+++ b/Sources/Contentful/ContentModellable.swift
@@ -136,7 +136,7 @@ public class ContentModel {
         return relationships
     }
 
-    func resolveRelationships() {
+    fileprivate func resolveRelationships() {
 
         for (entryId, fields) in relationshipsToResolve {
 
@@ -167,7 +167,7 @@ public class ContentModel {
         relationshipsToResolve.removeAll()
     }
 
-    static func cacheKey(for link: Link, with sourceLocaleCode: LocaleCode) -> String {
+    internal static func cacheKey(for link: Link, with sourceLocaleCode: LocaleCode) -> String {
         let linkType: String
         switch link {
         case .asset:

--- a/Sources/Contentful/DataCache.swift
+++ b/Sources/Contentful/DataCache.swift
@@ -14,14 +14,14 @@ internal class DataCache {
 
     static let cacheKeyDelimiter = "_"
 
-    public static func cacheKey(for resource: EntryModellable) -> String {
+    internal static func cacheKey(for resource: EntryModellable) -> String {
         let delimeter = DataCache.cacheKeyDelimiter
 
         let cacheKey =  resource.id + delimeter + "entry" + delimeter + resource.localeCode
         return cacheKey
     }
 
-    public static func cacheKey(for resource: LocalizableResource) -> String {
+    internal static func cacheKey(for resource: LocalizableResource) -> String {
         let delimeter = DataCache.cacheKeyDelimiter
 
         // Look at the type info.
@@ -40,19 +40,19 @@ internal class DataCache {
         entryCache.setObject(entry, forKey: DataCache.cacheKey(for: entry) as AnyObject)
     }
 
-    func asset(for identifier: String) -> Asset? {
+    internal func asset(for identifier: String) -> Asset? {
         return assetCache.object(forKey: identifier as AnyObject) as? Asset
     }
 
-    func entry(for identifier: String) -> EntryModellable? {
+    internal func entry(for identifier: String) -> EntryModellable? {
         return entryCache.object(forKey: identifier as AnyObject) as? EntryModellable
     }
 
-    func item<T>(for identifier: String) -> T? {
+    internal func item<T>(for identifier: String) -> T? {
         return item(for: identifier) as? T
     }
 
-    func item(for identifier: String) -> AnyObject? {
+    internal func item(for identifier: String) -> AnyObject? {
         var target: AnyObject? = self.asset(for: identifier)
 
         if target == nil {

--- a/Sources/Contentful/Entry.swift
+++ b/Sources/Contentful/Entry.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-
 /// An Entry represents a typed collection of data in Contentful
 public class Entry: LocalizableResource {
 

--- a/Sources/Contentful/Locale.swift
+++ b/Sources/Contentful/Locale.swift
@@ -52,12 +52,13 @@ public class Locale: ImmutableMappable {
  */
 public class LocalizationContext: MapContext {
 
-    // An ordered collection of locales representing the fallback chain.
-    internal let locales: [LocaleCode: Locale]
+    /// An ordered collection of locales representing the fallback chain.
+    public  let locales: [LocaleCode: Locale]
 
-    internal let `default`: Locale
+    /// The default locale of the space.
+    public let `default`: Locale
 
-    init(default: Locale, locales: [Locale]) {
+    internal init(default: Locale, locales: [Locale]) {
         self.`default` = `default`
 
         var localeMap = [LocaleCode: Locale]()

--- a/Sources/Contentful/Query.swift
+++ b/Sources/Contentful/Query.swift
@@ -15,15 +15,15 @@ import CoreLocation
 /// advantage of `Client` "fetch" methods that take `Query` types instead of constructing query dictionaries on your own.
 public struct QueryParameter {
 
-    static let contentType      = "content_type"
-    static let select           = "select"
-    static let order            = "order"
-    static let limit            = "limit"
-    static let skip             = "skip"
-    static let include          = "include"
-    static let locale           = "locale"
-    static let mimetypeGroup    = "mimetype_group"
-    static let fullTextSearch   = "query"
+    public static let contentType      = "content_type"
+    public static let select           = "select"
+    public static let order            = "order"
+    public static let limit            = "limit"
+    public static let skip             = "skip"
+    public static let include          = "include"
+    public static let locale           = "locale"
+    public static let mimetypeGroup    = "mimetype_group"
+    public static let fullTextSearch   = "query"
 }
 
 /**
@@ -38,13 +38,13 @@ public struct OrderParameter {
         self.propertyName = propertyName
     }
 
-    let propertyName: String
-    let reverse: Bool
+    internal let propertyName: String
+    internal let reverse: Bool
 }
 
 private struct QueryConstants {
-    static let maxLimit: UInt               = 1000
-    static let maxSelectedProperties: UInt  = 99
+    fileprivate static let maxLimit: UInt               = 1000
+    fileprivate static let maxSelectedProperties: UInt  = 99
 }
 
 /// Use types that conform to QueryableRange to perform queries with the four Range operators
@@ -679,7 +679,7 @@ public class Query: ChainableQuery {
      - Parameter id: the identifier of the content type which the query will be performed on.
      - Returns: A reference to the receiving query to enable chaining.
      */
-    @discardableResult func on(contentTypeFor id: ContentTypeId) -> Query {
+    @discardableResult public func on(contentTypeFor id: ContentTypeId) -> Query {
         self.parameters[QueryParameter.contentType] = id
         return self
     }

--- a/Sources/Contentful/Resource.swift
+++ b/Sources/Contentful/Resource.swift
@@ -114,7 +114,7 @@ public extension Dictionary where Key: ExpressibleByStringLiteral {
      - Parameter key: The name of the field to extract the `String` from
      - Returns: The `String` value, or `nil` if data contained is not convertible to a `String`.
      */
-    func string(at key: Key) -> String? {
+    public func string(at key: Key) -> String? {
         return self[key] as? String
     }
 
@@ -124,7 +124,7 @@ public extension Dictionary where Key: ExpressibleByStringLiteral {
      - Parameter key: The name of the field to extract the `[String]` from
      - Returns: The `[String]`, or nil if data contained is not convertible to an `[String]`.
      */
-    func strings(at key: Key) -> [String]? {
+    public func strings(at key: Key) -> [String]? {
         return self[key] as? [String]
     }
 
@@ -134,7 +134,7 @@ public extension Dictionary where Key: ExpressibleByStringLiteral {
      - Parameter key: The name of the field to extract the `Int` value from.
      - Returns: The `Int` value, or `nil` if data contained is not convertible to an `Int`.
      */
-    func int(at key: Key) -> Int? {
+    public func int(at key: Key) -> Int? {
         return self[key] as? Int
     }
 
@@ -144,7 +144,7 @@ public extension Dictionary where Key: ExpressibleByStringLiteral {
      - Parameter key: The name of the field to extract the `Date` value from.
      - Returns: The `Date` value, or `nil` if data contained is not convertible to a `Date`.
      */
-    func int(at key: Key) -> Date? {
+    public func int(at key: Key) -> Date? {
         let dateString = self[key] as? String
         let date = dateString?.iso8601StringDate
         return date
@@ -156,7 +156,7 @@ public extension Dictionary where Key: ExpressibleByStringLiteral {
      - Parameter key: The name of the field to extract the `Entry` from.
      - Returns: The `Entry` value, or `nil` if data contained does not have contain a Link referencing an `Entry`.
      */
-    func linkedEntry(at key: Key) -> Entry? {
+    public func linkedEntry(at key: Key) -> Entry? {
         let link = self[key] as? Link
         let entry = link?.entry
         return entry
@@ -168,7 +168,7 @@ public extension Dictionary where Key: ExpressibleByStringLiteral {
      - Parameter key: The name of the field to extract the `Asset` from.
      - Returns: The `Asset` value, or `nil` if data contained does not have contain a Link referencing an `Asset`.
      */
-    func linkedAsset(at key: Key) -> Asset? {
+    public func linkedAsset(at key: Key) -> Asset? {
         let link = self[key] as? Link
         let asset = link?.asset
         return asset
@@ -180,7 +180,7 @@ public extension Dictionary where Key: ExpressibleByStringLiteral {
      - Parameter key: The name of the field to extract the `[Entry]` from.
      - Returns: The `[Entry]` value, or `nil` if data contained does not have contain a Link referencing an `Entry`.
      */
-    func linkedEntries(at key: Key) -> [Entry]? {
+    public func linkedEntries(at key: Key) -> [Entry]? {
         let links = self[key] as? [Link]
         let entries = links?.flatMap { $0.entry }
         return entries
@@ -192,7 +192,7 @@ public extension Dictionary where Key: ExpressibleByStringLiteral {
      - Parameter key: The name of the field to extract the `[Asset]` from.
      - Returns: The `[Asset]` value, or `nil` if data contained does not have contain a Link referencing an `[Asset]`.
      */
-    func linkedAssets(at key: Key) -> [Asset]? {
+    public func linkedAssets(at key: Key) -> [Asset]? {
         let links = self[key] as? [Link]
         let assets = links?.flatMap { $0.asset }
         return assets
@@ -204,7 +204,7 @@ public extension Dictionary where Key: ExpressibleByStringLiteral {
      - Parameter key: The name of the field to extract the `CLLocationCoordinate2D` value from.
      - Returns: The `Bool` value, or `nil` if data contained is not convertible to a `Bool`.
      */
-    func bool(at key: Key) -> Bool? {
+    public func bool(at key: Key) -> Bool? {
         return self[key] as? Bool
     }
 
@@ -214,7 +214,7 @@ public extension Dictionary where Key: ExpressibleByStringLiteral {
      - Parameter key: The name of the field to extract the `Bool` value from.
      - Returns: The `Bool` value, or `nil` if data contained is not convertible to a `Bool`.
      */
-    func location(at key: Key) -> CLLocationCoordinate2D? {
+    public func location(at key: Key) -> CLLocationCoordinate2D? {
         let coordinateJSON = self[key] as? [String: Any]
         guard let longitude = coordinateJSON?["lon"] as? Double else { return nil }
         guard let latitude = coordinateJSON?["lat"] as? Double else { return nil }
@@ -238,12 +238,12 @@ public func == (lhs: Resource, rhs: Resource) -> Bool {
 }
 
 
-func +=<K: Hashable, V> (left: [K: V], right: [K: V]) -> [K: V] {
+internal func +=<K: Hashable, V> (left: [K: V], right: [K: V]) -> [K: V] {
     var result = left
     right.forEach { (key, value) in result[key] = value }
     return result
 }
 
-func +<K: Hashable, V> (left: [K: V], right: [K: V]) -> [K: V] {
+internal func +<K: Hashable, V> (left: [K: V], right: [K: V]) -> [K: V] {
     return left += right
 }

--- a/Sources/Contentful/SignalUtils.swift
+++ b/Sources/Contentful/SignalUtils.swift
@@ -10,12 +10,12 @@ import Foundation
 import Interstellar
 
 
-typealias SignalBang<U> = (@escaping (Result<U>) -> Void) -> URLSessionDataTask?
+public typealias SignalBang<U> = (@escaping (Result<U>) -> Void) -> URLSessionDataTask?
 
 // Take a QueryPattern to query on and closure that takes a Result of type U and reutrns a URLSessionData task...
-typealias AsyncDataTask<QueryPattern, U> = (QueryPattern, @escaping (Result<U>) -> Void) -> URLSessionDataTask?
+public typealias AsyncDataTask<QueryPattern, U> = (QueryPattern, @escaping (Result<U>) -> Void) -> URLSessionDataTask?
 
-func toObservable<QueryPattern, ResultType>(parameter: QueryPattern,
+internal func toObservable<QueryPattern, ResultType>(parameter: QueryPattern,
                asyncDataTask: AsyncDataTask<QueryPattern, ResultType>) -> (task: URLSessionDataTask?, observable: Observable<Result<ResultType>>) {
 
     let observable = Observable<Result<ResultType>>()
@@ -27,7 +27,7 @@ func toObservable<QueryPattern, ResultType>(parameter: QueryPattern,
     return (task, observable)
 }
 
-func toObservable<ResultType>(closure: SignalBang<ResultType>) -> (task: URLSessionDataTask?, observable: Observable<Result<ResultType>>) {
+internal func toObservable<ResultType>(closure: SignalBang<ResultType>) -> (task: URLSessionDataTask?, observable: Observable<Result<ResultType>>) {
 
     let observable = Observable<Result<ResultType>>()
     let task = closure { result in

--- a/Sources/Contentful/SyncSpace.swift
+++ b/Sources/Contentful/SyncSpace.swift
@@ -18,7 +18,7 @@ public final class SyncSpace: ImmutableMappable {
     public var deletedAssetIds = [String]()
     public var deletedEntryIds = [String]()
 
-    var hasMorePages: Bool
+    internal var hasMorePages: Bool
 
     /// A token which needs to be present to perform a subsequent synchronization operation
     internal(set) public var syncToken = ""
@@ -45,7 +45,7 @@ public final class SyncSpace: ImmutableMappable {
         self.syncToken = syncToken
     }
 
-    func syncToken(from urlString: String) -> String {
+    internal func syncToken(from urlString: String) -> String {
         guard let components = URLComponents(string: urlString)?.queryItems else { return "" }
         for component in components {
             if let value = component.value, component.name == "sync_token" {


### PR DESCRIPTION
Note that protocol members and enum cases cannot have a protection level set, they inherit the same protection level as the type itself