### PR TITLE
Support multiple callbacks per link.

### DIFF
--- a/Sources/Contentful/Decodable.swift
+++ b/Sources/Contentful/Decodable.swift
@@ -148,7 +148,7 @@ internal class LinkResolver {
         if callbacks[key] == nil {
             callbacks[key] = [callback]
         } else {
-            callbacks[key]!.append(callback)
+            callbacks[key]?.append(callback)
         }
     }
 
@@ -159,7 +159,7 @@ internal class LinkResolver {
         if callbacks[linksIdentifier] == nil {
             callbacks[linksIdentifier] = [callback]
         } else {
-            callbacks[linksIdentifier]!.append(callback)
+            callbacks[linksIdentifier]?.append(callback)
         }
     }
 

--- a/Sources/Contentful/Decodable.swift
+++ b/Sources/Contentful/Decodable.swift
@@ -126,7 +126,7 @@ internal class LinkResolver {
 
     private var dataCache: DataCache = DataCache()
 
-    private var callbacks: [String: (Any) -> Void] = [:]
+    private var callbacks: [String: [(Any) -> Void]] = [:]
 
     private static let linksArrayPrefix = "linksArrayPrefix"
 
@@ -144,30 +144,43 @@ internal class LinkResolver {
 
     // Caches the callback to resolve the relationship represented by a Link at a later time.
     internal func resolve(_ link: Link, inLocale localeCode: LocaleCode, callback: @escaping (Any) -> Void) {
-        callbacks[DataCache.cacheKey(for: link, with: localeCode)] = callback
+        let key = DataCache.cacheKey(for: link, with: localeCode)
+        if callbacks[key] == nil {
+            callbacks[key] = [callback]
+        } else {
+            callbacks[key]!.append(callback)
+        }
     }
 
     internal func resolve(_ links: [Link], inLocale localeCode: LocaleCode, callback: @escaping (Any) -> Void) {
         let linksIdentifier: String = links.reduce(into: LinkResolver.linksArrayPrefix) { (id, link) in
             id += "," + DataCache.cacheKey(for: link, with: localeCode)
         }
-        callbacks[linksIdentifier] = callback
+        if callbacks[linksIdentifier] == nil {
+            callbacks[linksIdentifier] = [callback]
+        } else {
+            callbacks[linksIdentifier]!.append(callback)
+        }
     }
 
     // Executes all cached callbacks to resolve links and then clears the callback cache and the data cache
     // where resources are cached before being resolved.
     internal func churnLinks() {
-        for (linkKey, callback) in callbacks {
+        for (linkKey, callbacksList) in callbacks {
             if linkKey.hasPrefix(LinkResolver.linksArrayPrefix) {
                 let firstKeyIndex = linkKey.index(linkKey.startIndex, offsetBy: LinkResolver.linksArrayPrefix.count)
                 let onlyKeysString = linkKey[firstKeyIndex ..< linkKey.endIndex]
                 // Split creates a [Substring] array, but we need [String] to index the cache
                 let keys = onlyKeysString.split(separator: ",").map { String($0) }
                 let items: [Any] = keys.map { dataCache.item(for: $0) as Any }
-                callback(items as Any)
+                for callback in callbacksList {
+                    callback(items as Any)
+                }
             } else {
                 let item = dataCache.item(for: linkKey)
-                callback(item as Any)
+                for callback in callbacksList {
+                    callback(item as Any)
+                }
             }
         }
         self.callbacks = [:]


### PR DESCRIPTION
I had an issue where the I had multiple Assets and Links being referenced by multiple objects. Because the cache only holds one callback per object, the callbacks of any prior referencing objects were being overwritten. The code now has an array of callbacks instead of a single callback per referenced object.