### PR TITLE
Fixes for decoding of ImageInfo

### DIFF
--- a/Sources/Contentful/Asset.swift
+++ b/Sources/Contentful/Asset.swift
@@ -81,8 +81,28 @@ public class Asset: LocalizableResource, ResourceQueryable {
             public let imageInfo: ImageInfo?
 
             public struct ImageInfo: Decodable {
-                let width: Double
-                let height: Double
+                public let width: Double
+                public let height: Double
+                
+                public init(from decoder: Decoder) throws {
+                    let container = try decoder.container(keyedBy: CodingKeys.self)
+                    width         = try container.decode(Double.self, forKey: .width)
+                    height        = try container.decode(Double.self, forKey: .height)
+                }
+                
+                private enum CodingKeys: String, CodingKey {
+                    case width, height
+                }
+            }
+            
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                size          = try container.decode(Int.self, forKey: .size)
+                imageInfo     = try container.decode(ImageInfo.self, forKey: .image)
+            }
+            
+            private enum CodingKeys: String, CodingKey {
+                case size, image
             }
         }
 

--- a/Tests/ContentfulTests/AssetTests.swift
+++ b/Tests/ContentfulTests/AssetTests.swift
@@ -42,8 +42,6 @@ class AssetTests: XCTestCase {
             case let .success(asset):
                 expect(asset.sys.id).to(equal("nyancat"))
                 expect(asset.sys.type).to(equal("Asset"))
-                expect(asset.file?.details?.imageInfo?.width).to(equal(250.0))
-                expect(asset.file?.details?.imageInfo?.height).to(equal(250.0))
                 expect(url(asset).absoluteString).to(equal("https://images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png"))
             case let .error(error):
                 fail("\(error)")

--- a/Tests/ContentfulTests/AssetTests.swift
+++ b/Tests/ContentfulTests/AssetTests.swift
@@ -42,6 +42,8 @@ class AssetTests: XCTestCase {
             case let .success(asset):
                 expect(asset.sys.id).to(equal("nyancat"))
                 expect(asset.sys.type).to(equal("Asset"))
+                expect(asset.file?.details?.imageInfo?.width).to(equal(250.0))
+                expect(asset.file?.details?.imageInfo?.height).to(equal(250.0))
                 expect(url(asset).absoluteString).to(equal("https://images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png"))
             case let .error(error):
                 fail("\(error)")

--- a/Tests/ContentfulTests/JSONDecodingTests.swift
+++ b/Tests/ContentfulTests/JSONDecodingTests.swift
@@ -54,6 +54,8 @@ class JSONDecodingTests: XCTestCase {
             expect(asset.sys.id).to(equal("nyancat"))
             expect(asset.sys.type).to(equal("Asset"))
             expect(asset.sys.createdAt).toNot(beNil())
+            expect(asset.file?.details?.imageInfo?.width).to(equal(250.0))
+            expect(asset.file?.details?.imageInfo?.height).to(equal(250.0))
             expect(try asset.url()).to(equal(URL(string: "https://images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png")))
         } catch _ {
             fail("Asset decoding should not throw an error")


### PR DESCRIPTION
The `imageInfo` property of `Assets.FileMetadata.Details` was not populated, the value was `nil`.