### PR TITLE
Don't prepend "fields." to field paths twice when using typed queries

### DIFF
--- a/Sources/Contentful/Query.swift
+++ b/Sources/Contentful/Query.swift
@@ -571,8 +571,8 @@ public extension AbstractResourceQuery {
 
      See: <https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/select-operator>
      - Parameter fieldNames: An array of field names to include in the JSON response.
-     - Throws: Will throw an error if selections go more than 2 levels deep
-     ("fields.bestFriend.sys" is not valid), or if more than 99 properties are selected.
+     - Throws: Will throw an error if selections go more than 1 level deep within the fields container ("bestFriend.sys" is not
+     valid), or if more than 99 properties are selected.
      */
     public static func select(fieldsNamed fieldNames: [FieldName]) throws -> Self {
         let query = Self()
@@ -588,7 +588,7 @@ public extension AbstractResourceQuery {
      Example usage:
 
      ```
-     let query = try! Query().select(fieldsNamed: ["fields.bestFriend", "fields.color", "fields.name"])
+     let query = try! Query().select(fieldsNamed: ["bestFriend", "color", "name"])
      client.fetchEntries(with: query).observable.then { catsResponse in
          let cats = catsResponse.items
          // Do stuff with cats.
@@ -597,8 +597,8 @@ public extension AbstractResourceQuery {
 
      See: <https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/select-operator>
      - Parameter fieldNames: An array of field names to include in the JSON response.
-     - Throws: Will throw an error if property names are not prefixed with `"fields."`, if selections go more than 2 levels deep
-     ("fields.bestFriend.sys" is not valid), or if more than 99 properties are selected.
+     - Throws: Will throw an error if selections go more than 1 level deep within the fields container ("bestFriend.sys" is not
+     valid), or if more than 99 properties are selected.
      - Returns: A reference to the receiving query to enable chaining.
      */
     @discardableResult public func select(fieldsNamed fieldNames: [FieldName]) throws -> Self {

--- a/Sources/Contentful/TypedQuery.swift
+++ b/Sources/Contentful/TypedQuery.swift
@@ -199,7 +199,7 @@ public final class QueryOn<EntryType>: EntryQuery where EntryType: EntryDecodabl
      - Returns: A reference to the receiving query to enable chaining.
      */
     @discardableResult public func select(fieldsNamed fieldsKeys: [EntryType.Fields]) -> QueryOn<EntryType> {
-        let fieldPaths = fieldsKeys.map { "fields.\($0.stringValue)" }
+        let fieldPaths = fieldsKeys.map { $0.stringValue }
         try! self.select(fieldsNamed: fieldPaths)
         return self
     }

--- a/Sources/Contentful/TypedQuery.swift
+++ b/Sources/Contentful/TypedQuery.swift
@@ -341,7 +341,7 @@ public final class AssetQuery: ResourceQuery {
      - Returns: A reference to the receiving query to enable chaining.
      */
     @discardableResult public func select(fields fieldsKeys: [Asset.Fields]) -> AssetQuery {
-        let fieldPaths = fieldsKeys.map { "fields.\($0.stringValue)" }
+        let fieldPaths = fieldsKeys.map { $0.stringValue }
         // Because we're guaranteed the keyPath doesn't have a "." in it, we can force try
         try! self.select(fieldsNamed: fieldPaths)
         return self

--- a/Tests/ContentfulTests/QueryTests.swift
+++ b/Tests/ContentfulTests/QueryTests.swift
@@ -468,6 +468,27 @@ class QueryTests: XCTestCase {
         waitForExpectations(timeout: 10.0, handler: nil)
     }
 
+    func testQueryAssetsWithSelectUsingFields() {
+        let expectation = self.expectation(description: "Equality operator expectation")
+
+        let query = AssetQuery.where(sys: .id, .equals("1x0xpXu4pSGS4OukSyWGUK"))
+        query.select(fields: [.title])
+
+        QueryTests.client.fetchAssets(matching: query) { result in
+            switch result {
+            case .success(let assetsResponse):
+                let assets = assetsResponse.items
+                expect(assets.count).to(equal(1))
+                expect(assets.first?.sys.id).to(equal("1x0xpXu4pSGS4OukSyWGUK"))
+                expect(assets.first?.fields["title"] as? String).to(equal("Doge"))
+            case .error(let error):
+                fail("Should not throw an error \(error)")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
+
     func testQueryValidation() {
         let fieldNames = ["sys.contentType.sys.id"]
 

--- a/Tests/ContentfulTests/QueryTests.swift
+++ b/Tests/ContentfulTests/QueryTests.swift
@@ -154,6 +154,35 @@ class QueryTests: XCTestCase {
         waitForExpectations(timeout: 10.0, handler: nil)
     }
 
+    func testQueryReturningClientDefinedModelUsingFields() {
+        let expectation = self.expectation(description: "Select operator expectation")
+        let query = QueryOn<Cat>.select(fieldsNamed: [
+            .bestFriend,
+            .color,
+            .name,
+        ])
+
+        QueryTests.client.fetchMappedEntries(matching: query) { result in
+            switch result {
+            case .success(let catsResponse):
+                let cats = catsResponse.items
+                let nyanCat = cats.first!
+                expect(nyanCat.color).toNot(beNil())
+                expect(nyanCat.name).to(equal("Nyan Cat"))
+                // Test links
+                expect(nyanCat.bestFriend?.name).to(equal("Happy Cat"))
+
+                // Test uniqueness in memory.
+                expect(nyanCat).to(be(nyanCat.bestFriend?.bestFriend))
+            case .error(let error):
+                fail("Should not throw an error \(error)")
+            }
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
+
     func testQueryReturningHeterogeneousArray() {
 
         let expectation = self.expectation(description: "Fetch all entries expectation")


### PR DESCRIPTION
Selecting fields using the `Fields` associated type fails query validation because keys are prefixed with `fields.fields.`.

I'm not sure which direction this fix should go in though, as there's a comment on `.select(fieldsNamed: [String])` that it throws if paths are not prefixed with `fields.`, but that function immediately prefixes its arguments?
https://github.com/contentful/contentful.swift/blob/12be3854979078666d3348b0fb3781d5ea664a24/Sources/Contentful/Query.swift#L600-L608