### PR TITLE
Fix memory leak: NSURLSession never invalidated

### DIFF
--- a/Sources/Contentful/Client.swift
+++ b/Sources/Contentful/Client.swift
@@ -298,6 +298,10 @@ open class Client {
             completion(Result.error(SDKError.unparseableJSON(data: data, errorMessage: "The SDK was unable to parse the JSON: \(error)")))
         }
     }
+    
+    deinit {
+        urlSession.invalidateAndCancel()
+    }
 }
 
 extension Client {


### PR DESCRIPTION
I quote from Apple's [documentation](https://developer.apple.com/documentation/foundation/nsurlsession) on `NSURSession`:
"The session object keeps a strong reference to the delegate until your app exits or explicitly invalidates the session. If you don’t invalidate the session, your app leaks memory until it exits."

Since `self.urlSession` is created when `Client` is initialized, it must also be invalidated when self is deallocated.