### PR TITLE
Delay churnLinks call and wait until LinkResolver finishes its work

### DIFF
--- a/Sources/Contentful/ArrayResponse.swift
+++ b/Sources/Contentful/ArrayResponse.swift
@@ -157,9 +157,6 @@ extension HomogeneousArrayResponse: Decodable {
 
             // Cache to enable link resolution.
             decoder.linkResolver.cache(entryDecodables: self.items as! [EntryDecodable])
-
-            // Resolve links.
-            decoder.linkResolver.churnLinks()
         } else {
 
             // Since self's items are NOT of a custom (i.e. user-defined) type,
@@ -272,9 +269,6 @@ extension HeterogeneousArrayResponse: Decodable {
 
         // Cache to enable link resolution.
         decoder.linkResolver.cache(entryDecodables: self.items)
-
-        // Resolve links.
-        decoder.linkResolver.churnLinks()
     }
 }
 


### PR DESCRIPTION
Discussion: https://github.com/contentful/contentful.swift/issues/296 – Please read my comment before code review starts.

What's new:
- Delayed `churnLinks` call so it is not called from the `HeterogenousArrayResponse` or `HomogenousArrayResponse` but instead this is called internally by the `LinkResolver`. Thanks to that there should be no race conditions when on the one hand `*ArrayResponse` classes finish it's decoding but on the other hand some models are still awaiting link resolving async callbacks.
- Prevented data cache clearing when the callbacks dictionary is not empty after resolving links.
- Put the comment on the `LinkResolver` to mark that this is a single instance that is used among multiple calls that can happen at the same time and could lead to some links not being resolved correctly – This is something that should be discussed by the Support Team.

New logic would be like this:
1) `Client.fetch(url:then:)` is called by the user.
2) `Client.handleJSON(data:completion)` is called after the successful fetch.
3) `LinkResolver.perform(decoding:completion:)` is called right away.
4) `*ArrayResponse` decodes its content as usual but does not call the `churnLinks` after the synchronous work is done as it was done before.
5) `LinkResolver` calls `churnLinks` (itself) right after synchronous work is done in step 4.
6) When all the `LinkResolver.callbacks` are executed and removed then the `LinkResolver` itself calls the completion of the link resolving process - not earlier, not later.
7) Callback of `Client.fetch(url:then:)` is called when all your models are fully instantiated.