### PR TITLE
Speed up entry and asset link resolving

### DIFF
--- a/Sources/Contentful/ArrayResponse.swift
+++ b/Sources/Contentful/ArrayResponse.swift
@@ -178,12 +178,12 @@ extension HomogeneousArrayResponse: Decodable {
             for asset in (includedAssets ?? []) {
                 assetsMap[asset.sys.id] = asset
             }
-            
+
             var entriesMap = [String: Entry]()
             for entry in allIncludedEntries {
                 entriesMap[entry.sys.id] = entry
             }
-            
+
             // Rememember `Entry`s are classes (passed by reference) so we can change them in place.
             for entry in allIncludedEntries {
                 entry.resolveLinks(against: entriesMap, and: assetsMap)

--- a/Sources/Contentful/ArrayResponse.swift
+++ b/Sources/Contentful/ArrayResponse.swift
@@ -174,9 +174,19 @@ extension HomogeneousArrayResponse: Decodable {
 
             let allIncludedEntries = entries + (includedEntries ?? [])
 
+            var assetsMap = [String: Asset]()
+            for asset in (includedAssets ?? []) {
+                assetsMap[asset.sys.id] = asset
+            }
+            
+            var entriesMap = [String: Entry]()
+            for entry in allIncludedEntries {
+                entriesMap[entry.sys.id] = entry
+            }
+            
             // Rememember `Entry`s are classes (passed by reference) so we can change them in place.
             for entry in allIncludedEntries {
-                entry.resolveLinks(against: allIncludedEntries, and: (includedAssets ?? []))
+                entry.resolveLinks(against: entriesMap, and: assetsMap)
             }
         }
     }

--- a/Sources/Contentful/Entry.swift
+++ b/Sources/Contentful/Entry.swift
@@ -66,7 +66,7 @@ public class Entry: LocalizableResource {
          - includedEntries: `Entry` candidates that `self` _could_ link to.
          - includedAssets: `Asset` candidates that `self` _could_ link to.
     */
-    internal func resolveLinks(against includedEntries: [Entry]?, and includedAssets: [Asset]?) {
+    internal func resolveLinks(against includedEntries: [String: Entry], and includedAssets: [String: Asset]) {
         var localizableFields = [FieldName: [LocaleCode: Any]]()
 
         for (fieldName, localizableFieldMap) in self.localizableFields {

--- a/Sources/Contentful/Link.swift
+++ b/Sources/Contentful/Link.swift
@@ -108,16 +108,16 @@ public enum Link: Codable {
      - includedEntries: `Entry` candidates that `self` _could_ point at.
      - includedAssets: `Asset` candidates that `self` _could_ point at.
      */
-    internal func resolve(against includedEntries: [Entry]?, and includedAssets: [Asset]?) -> Link {
+    internal func resolve(against includedEntries: [String: Entry], and includedAssets: [String: Asset]) -> Link {
         switch self {
         case .unresolved(let sys):
             switch sys.linkType {
             case "Entry":
-                if let entry = (includedEntries?.filter { $0.sys.id == sys.id })?.first {
+                if let entry = includedEntries[sys.id] {
                     return Link.entry(entry)
                 }
             case "Asset":
-                if let asset = (includedAssets?.filter { return $0.sys.id == sys.id })?.first {
+                if let asset = includedAssets[sys.id] {
                     return Link.asset(asset)
                 }
             default:

--- a/Sources/Contentful/QueryOperation.swift
+++ b/Sources/Contentful/QueryOperation.swift
@@ -43,7 +43,7 @@ public extension Query {
         /// Full text search on a field.
         case matches(String)
 
-        /// MARK: Ranges
+        // MARK: Ranges
 
         /// Less-than operator: <https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/ranges>
         case isLessThan(QueryableRange)

--- a/Sources/Contentful/Resource.swift
+++ b/Sources/Contentful/Resource.swift
@@ -170,7 +170,7 @@ public class LocalizableResource: Resource, FlatResource, Codable {
 
 // MARK: Internal
 
-extension LocalizableResource: Hashable {    
+extension LocalizableResource: Hashable {
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(id)

--- a/Sources/Contentful/RichText.swift
+++ b/Sources/Contentful/RichText.swift
@@ -17,12 +17,12 @@ public protocol Node: Codable {
 
 public protocol RecursiveNode: Node {
     var content: [Node] { get }
-    func resolveLinks(against includedEntries: [Entry]?, and includedAssets: [Asset]?)
+    func resolveLinks(against includedEntries: [String: Entry], and includedAssets: [String: Asset])
 }
 
 private extension RecursiveNode {
 
-    func resolveLinksInChildNodes(against includedEntries: [Entry]?, and includedAssets: [Asset]?) {
+    func resolveLinksInChildNodes(against includedEntries: [String: Entry], and includedAssets: [String: Asset]) {
         self.content.forEach { node in
             switch node {
             case let recursiveNode as RecursiveNode:
@@ -164,7 +164,7 @@ public class BlockNode: RecursiveNode {
         self.content = content
     }
 
-    public func resolveLinks(against includedEntries: [Entry]?, and includedAssets: [Asset]?) {
+    public func resolveLinks(against includedEntries: [String: Entry], and includedAssets: [String: Asset]) {
         resolveLinksInChildNodes(against: includedEntries, and: includedAssets)
     }
 
@@ -191,7 +191,7 @@ public class InlineNode: RecursiveNode {
         self.content = content
     }
 
-    public func resolveLinks(against includedEntries: [Entry]?, and includedAssets: [Asset]?) {
+    public func resolveLinks(against includedEntries: [String: Entry], and includedAssets: [String: Asset]) {
         resolveLinksInChildNodes(against: includedEntries, and: includedAssets)
     }
 
@@ -246,7 +246,7 @@ public class InlineNode: RecursiveNode {
         }
     }
 
-    public func resolveLinks(against includedEntries: [Entry]?, and includedAssets: [Asset]?) {
+    public func resolveLinks(against includedEntries: [String: Entry], and includedAssets: [String: Asset]) {
         resolveLinksInChildNodes(against: includedEntries, and: includedAssets)
     }
 
@@ -359,19 +359,19 @@ public class ResourceLinkBlock: BlockNode {
         try super.init(from: decoder)
     }
 
-    public override func resolveLinks(against includedEntries: [Entry]?, and includedAssets: [Asset]?) {
+    public override func resolveLinks(against includedEntries: [String: Entry], and includedAssets: [String: Asset]) {
         switch data.target {
         case .asset, .entry, .entryDecodable:
             return
         case let .unresolved(sys):
             switch sys.linkType.lowercased() {
             case "entry":
-                guard let linkedEntry = includedEntries?.first(where: { $0.sys.id == sys.id }) else {
+                guard let linkedEntry = includedEntries[sys.id] else {
                     return
                 }
                 data.target = Link.entry(linkedEntry)
             case "asset":
-                guard let linkedAsset = includedAssets?.first(where: { $0.sys.id == sys.id }) else {
+                guard let linkedAsset = includedAssets[sys.id] else {
                     return
                 }
                 data.target = Link.asset(linkedAsset)
@@ -405,19 +405,19 @@ public class ResourceLinkInline: InlineNode {
         try super.init(from: decoder)
     }
 
-    public override func resolveLinks(against includedEntries: [Entry]?, and includedAssets: [Asset]?) {
+    public override func resolveLinks(against includedEntries: [String: Entry], and includedAssets: [String: Asset]) {
         switch data.target {
         case .asset, .entry, .entryDecodable:
             return
         case let .unresolved(sys):
             switch sys.linkType.lowercased() {
             case "entry":
-                guard let linkedEntry = includedEntries?.first(where: { $0.sys.id == sys.id }) else {
+                guard let linkedEntry = includedEntries[sys.id] else {
                     return
                 }
                 data.target = Link.entry(linkedEntry)
             case "asset":
-                guard let linkedAsset = includedAssets?.first(where: { $0.sys.id == sys.id }) else {
+                guard let linkedAsset = includedAssets[sys.id] else {
                     return
                 }
                 data.target = Link.asset(linkedAsset)

--- a/Sources/Contentful/SyncSpace.swift
+++ b/Sources/Contentful/SyncSpace.swift
@@ -160,7 +160,7 @@ public final class SyncSpace: Decodable {
         for entry in entries {
             entry.resolveLinks(against: entriesMap, and: assetsMap)
         }
-        
+
         for asset in syncSpace.assets {
             assetsMap[asset.sys.id] = asset
         }

--- a/Sources/Contentful/SyncSpace.swift
+++ b/Sources/Contentful/SyncSpace.swift
@@ -156,6 +156,11 @@ public final class SyncSpace: Decodable {
 
     internal func updateWithDiffs(from syncSpace: SyncSpace) {
 
+        // Resolve all entries in-memory.
+        for entry in entries {
+            entry.resolveLinks(against: entriesMap, and: assetsMap)
+        }
+        
         for asset in syncSpace.assets {
             assetsMap[asset.sys.id] = asset
         }
@@ -163,11 +168,6 @@ public final class SyncSpace: Decodable {
         // Update and deduplicate all entries.
         for entry in syncSpace.entries {
             entriesMap[entry.sys.id] = entry
-        }
-
-        // Resolve all entries in-memory.
-        for entry in entries {
-            entry.resolveLinks(against: entries, and: assets)
         }
 
         for deletedAssetId in syncSpace.deletedAssetIds {


### PR DESCRIPTION
We ran into performance problems when syncing our content model. 
Profiling unveiled that a significant amount of processing time is spent resolving entry and asset links.

This PR improves resolving performance drastically by using key-based entry/asset mappings.

Time Profiling on iPhone 11 Pro on iOS 14.2:
Our test space spent approximately 16 seconds in `Entry.resolveLinks`, this PR reduces this below 1sec.

<img width="1087" alt="Screenshot 2020-11-21 at 00 59 20" src="https://user-images.githubusercontent.com/213965/99860907-d72ae980-2b94-11eb-9001-73c1ecb1aff2.png">

<img width="1083" alt="Screenshot 2020-11-21 at 00 48 18" src="https://user-images.githubusercontent.com/213965/99860914-d98d4380-2b94-11eb-8948-2ca02833222b.png">
