### PR TITLE
Fix calling completion closure twice

### DIFF
--- a/Sources/Contentful/Client.swift
+++ b/Sources/Contentful/Client.swift
@@ -169,7 +169,7 @@ open class Client {
         let finishDataFetch: (ResultsHandler<Data>) = { result in
             switch result {
             case .success(let mappableData):
-                self.handleJSON(data: mappableData, completion: completion)
+                completion(self.handleJSON(data: mappableData))
             case .failure(let error):
                 completion(.failure(error))
             }
@@ -382,12 +382,7 @@ open class Client {
             return nil
         }
         return fetchCurrentSpaceLocales { result in
-            switch result {
-            case .success(let localesResponse):
-                completion(Result.success(localesResponse.items))
-            case .failure(let error):
-                completion(.failure(error))
-            }
+            completion(result.map { $0.items })
         }
     }
 
@@ -421,20 +416,21 @@ open class Client {
         // At this point, We know for sure that the type returned by the API can be mapped to an `APIError` instance.
         // Directly handle JSON and exit.
         let statusCode = (response as! HTTPURLResponse).statusCode
-        self.handleRateLimitJSON(
+        let result = handleRateLimitJSON(
             data: data,
             timeUntilLimitReset: timeUntilLimitReset,
             statusCode: statusCode,
             jsonDecoder: jsonDecoder
-        ) { (_ result: Result<RateLimitError, Error>) in
-            switch result {
-            case .success(let rateLimitError):
-                completion(.failure(rateLimitError))
-            case .failure(let auxillaryError):
-                // We should never get here, but we'll bubble up what should be a `SDKError.unparseableJSON` error just in case.
-                completion(.failure(auxillaryError))
-            }
+        )
+
+        switch result {
+        case .success(let rateLimitError):
+            completion(.failure(rateLimitError))
+        case .failure(let auxillaryError):
+            // We should never get here, but we'll bubble up what should be a `SDKError.unparseableJSON` error just in case.
+            completion(.failure(auxillaryError))
         }
+
         return true
     }
 
@@ -442,12 +438,10 @@ open class Client {
         data: Data,
         timeUntilLimitReset: Int,
         statusCode: Int,
-        jsonDecoder: JSONDecoder,
-        completion: ResultsHandler<RateLimitError>
-    ) {
+        jsonDecoder: JSONDecoder
+    ) -> Result<RateLimitError, Error> {
         guard let rateLimitError = try? jsonDecoder.decode(RateLimitError.self, from: data) else {
-            completion(.failure(SDKError.unparseableJSON(data: data, errorMessage: "SDK unable to parse RateLimitError payload")))
-            return
+            return .failure(SDKError.unparseableJSON(data: data, errorMessage: "SDK unable to parse RateLimitError payload"))
         }
         rateLimitError.statusCode = statusCode
         rateLimitError.timeBeforeLimitReset = timeUntilLimitReset
@@ -458,13 +452,10 @@ open class Client {
         """
         ContentfulLogger.log(.error, message: errorMessage)
         // In this case, .success means that a RateLimitError was successfully initialized.
-        completion(Result.success(rateLimitError))
+        return .success(rateLimitError)
     }
 
-    private func handleJSON<DecodableType: Decodable>(
-        data: Data,
-        completion: @escaping ResultsHandler<DecodableType>
-    ) {
+    private func handleJSON<DecodableType: Decodable>(data: Data) -> Result<DecodableType, Error> {
         let jsonDecoder = jsonDecoderBuilder.build()
 
         var decodedObject: DecodableType?
@@ -473,7 +464,7 @@ open class Client {
         } catch let error {
             let sdkError = SDKError.unparseableJSON(data: data, errorMessage: "\(error)")
             ContentfulLogger.log(.error, message: sdkError.message)
-            completion(.failure(sdkError))
+            return .failure(sdkError)
         }
 
         guard let linkResolver = jsonDecoder.userInfo[.linkResolverContextKey] as? LinkResolver else {
@@ -482,22 +473,21 @@ open class Client {
                 errorMessage: "Couldn't find link resolver instance."
             )
             ContentfulLogger.log(.error, message: error.message)
-            completion(.failure(error))
-            return
+            return .failure(error)
         }
 
         linkResolver.churnLinks()
 
         // Make sure decoded object is not nil before calling success completion block.
         if let decodedObject = decodedObject {
-            completion(.success(decodedObject))
+            return .success(decodedObject)
         } else {
             let error = SDKError.unparseableJSON(
                 data: data,
                 errorMessage: "Unknown error occured during decoding."
             )
             ContentfulLogger.log(.error, message: error.message)
-            completion(.failure(error))
+            return .failure(error)
         }
     }
 }


### PR DESCRIPTION
Prevents calling `completion` closures multiple times by making the synchronous `Client` `Result` handling methods return their values rather than having `completion` parameters.

The changed method signatures are `private` so the change is non-breaking.