### PR TITLE
Fix decoding error for embedded entry-hyperlinks

### DIFF
--- a/Sources/Contentful/RichText.swift
+++ b/Sources/Contentful/RichText.swift
@@ -405,6 +405,12 @@ public class ResourceLinkInline: InlineNode {
         try super.init(from: decoder)
     }
 
+    public override func encode(to encoder: Encoder) throws {
+        try super.encode(to: encoder)
+        var container = encoder.container(keyedBy: NodeContentCodingKeys.self)
+        try container.encode(data, forKey: .data)
+    }
+    
     public override func resolveLinks(against includedEntries: [String: Entry], and includedAssets: [String: Asset]) {
         switch data.target {
         case .asset, .entry, .entryDecodable:


### PR DESCRIPTION
We experienced a decoding error when we had a hyperlink linking to another entry that contains another hyperlink in its content block.

Turned out that it was an issue due to missing encoding for ResourceLinkInline - the data property was not encoded, which led to a decoding error.