### PR TITLE
Avoids calling completion twice on failure

### DIFF
--- a/Sources/Contentful/Client.swift
+++ b/Sources/Contentful/Client.swift
@@ -468,14 +468,13 @@ open class Client {
         let jsonDecoder = jsonDecoderBuilder.build()
 
         var decodedObject: DecodableType?
-        var initialDecodeFailed: Bool = false
         do {
             decodedObject = try jsonDecoder.decode(DecodableType.self, from: data)
         } catch let error {
             let sdkError = SDKError.unparseableJSON(data: data, errorMessage: "\(error)")
             ContentfulLogger.log(.error, message: sdkError.message)
             completion(.failure(sdkError))
-            initialDecodeFailed = true
+            return
         }
 
         guard let linkResolver = jsonDecoder.userInfo[.linkResolverContextKey] as? LinkResolver else {
@@ -500,7 +499,6 @@ open class Client {
             )
             ContentfulLogger.log(.error, message: error.message)
             
-            guard !initialDecodeFailed else { return }
             completion(.failure(error))
         }
     }


### PR DESCRIPTION
Swift's concurrency Task API will crash if completion handlers are called more than once in continuations.
This is a critical issue affecting the Contentful SDK and this PR patches one case of it happening.

I encountered this because I've wrapped `fetchArray(of` in a `Task` and this triggers:
`Fatal error: SWIFT TASK CONTINUATION MISUSE: fetchArray(of:) tried to resume its continuation more than once, throwing Unknown error occured during decoding.!`
In my case I was mistakenly decoding a value using `decode` rather than `decodeIfPresent`.

Here's the client code to repro (if you decode erroneously as described above).

```swift
func fetchArray<ResourceType: EntryDecodable & FieldKeysQueryable>(of resourceType: ResourceType.Type) async throws -> [ResourceType] {
        
        try await withCheckedThrowingContinuation { continuation in
            fetchArray(of: resourceType) { result in
                switch result {
                case .success(let results):
                    continuation.resume(returning: results.items.map { $0 as ResourceType })
                case .failure(let error):
                    continuation.resume(throwing: error)
                }
            }
        }
    }
```

Client.swift:476 and 500 in Contentful 5.5.2.