### PR TITLE
fix: bump xcode version to supported v13 for CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,28 +31,28 @@ commands:
 jobs:
   test-ios:
     macos:
-      xcode: 13.3.1
+      xcode: 13.4.1
     steps:
       - setup-deps
       - run: fastlane test_ios
 
   test-macos:
     macos:
-      xcode: 13.3.1
+      xcode: 13.4.1
     steps:
       - setup-deps
       - run: fastlane test_macos
 
   test-tvos:
     macos:
-      xcode: 13.3.1
+      xcode: 13.4.1
     steps:
       - setup-deps
       - run: fastlane test_tvos
 
   build:
     macos:
-      xcode: 13.3.1
+      xcode: 13.4.1
     steps:
       - setup-deps
       - run: fastlane build


### PR DESCRIPTION
the previously configured version is no longer supported: https://circleci.com/docs/using-macos/

Note: the tests are still failing because the setup has atrophied without investment in keeping it up to date with newer XCode/OS X/iOS/tvOS/etc versions. This piece will require more follow up, but the test suite actually runs now, whereas it was not before with deprecated Mac images.