### PR TITLE
chore: Updated `Package.swift`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,7 +1,24 @@
 {
   "object": {
     "pins": [
-
+      {
+        "package": "DVR",
+        "repositoryURL": "https://github.com/mariuskatcontentful/DVR.git",
+        "state": {
+          "branch": "master",
+          "revision": "fb4f8678b1479320b9926d37732494d8cce85432",
+          "version": null
+        }
+      },
+      {
+        "package": "OHHTTPStubs",
+        "repositoryURL": "https://github.com/mariuskatcontentful/OHHTTPStubs.git",
+        "state": {
+          "branch": "master",
+          "revision": "1c5f7b4348cccdd1128fe5fb89f0e1f3191adc68",
+          "version": null
+        }
+      }
     ]
   },
   "version": 1

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.3
 import PackageDescription
 
 public let package = Package(
@@ -6,10 +6,28 @@ public let package = Package(
     products: [
         .library(
             name: "Contentful",
-            targets: ["Contentful"])
+            targets: ["Contentful"]
+        )
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/mariuskatcontentful/DVR.git",
+            .branch("master")
+        ),
+        .package(
+            url: "https://github.com/mariuskatcontentful/OHHTTPStubs.git",
+            .branch("master")
+        )
     ],
     targets: [
         .target(
-            name: "Contentful")
+            name: "Contentful"),
+        .testTarget(name: "ContentfulTests",
+                    dependencies: [
+                        "Contentful",
+                        .product(name: "DVR", package: "DVR"),
+                        .product(name: "OHHTTPStubs", package: "OHHTTPStubs")
+                    ],
+                    path: "Tests")
     ]
 )


### PR DESCRIPTION
## Summary
Updates the Swift tools version to 5.3 and adds new dependencies for DVR and OHHTTPStubs inside SPM, so that tests can be run inside Xcode directly without requiring Carthage.