### PR TITLE
fix: prevent null values in resolved objects arrays

### DIFF
--- a/Sources/Contentful/LinkResolver.swift
+++ b/Sources/Contentful/LinkResolver.swift
@@ -46,7 +46,7 @@ class LinkResolver {
                 let onlyKeysString = linkKey[firstKeyIndex ..< linkKey.endIndex]
                 // Split creates a [Substring] array, but we need [String] to index the cache
                 let keys = onlyKeysString.split(separator: ",").map { String($0) }
-                let items: [AnyObject] = keys.compactMap { dataCache.item(for: $0) }
+                let items = keys.compactMap { dataCache.item(for: $0) }
                 for callback in callbacksList {
                     callback(items as AnyObject)
                 }


### PR DESCRIPTION
This PR makes sure resolved objects array does not contain nil values. 

Using compact map should have removed them but enforcing [AnyObject] type of end object resulted in implicit cast of nil to NSNull which was no longer removed for beying an object. This behavior was prevented by removing the explicit object type.