### PR TITLE
Support strikethrough text

### DIFF
--- a/Sources/Contentful/RichText.swift
+++ b/Sources/Contentful/RichText.swift
@@ -495,6 +495,8 @@ public struct Text: Node, Equatable {
         case superscript
         /// Text formatted as subscript
         case `subscript`
+        /// Strikethrough text
+        case strikethrough
     }
 }
 


### PR DESCRIPTION
The decoding process failed to decode rich text if a `strikethrough` mark was present in the content.

This patch adds the missing mark to the `MarkType` enum, and this is sufficient for the decoding process to succeed, and to pass the required data to the application as a rich text document.