### PR TITLE
fix: resourceLink added to the FieldType so that decoding process works as expected

### DIFF
--- a/Sources/Contentful/FieldType.swift
+++ b/Sources/Contentful/FieldType.swift
@@ -45,4 +45,7 @@ public enum FieldType: String, Decodable {
 
     /// The rich text field type.
     case richText = "RichText"
+    
+    /// The resource link field type
+    case resourceLink = "ResourceLink"
 }


### PR DESCRIPTION
### Summary
This PR adds support for the `ResourceLink` field type in the iOS SDK.

### Background
- When using the Sync API on iOS, we encountered a `dataCorrupted` decoding error: Cannot initialize FieldType from "ResourceLink"
- The same token and sync method work correctly on Android.
- On review, we noticed that the Android SDK includes `ResourceLink` in its `FieldType` enum, but the iOS SDK does not.

### Fix
- Added `resourceLink` to the `FieldType` enum.
- With this change, the Sync API works correctly on iOS without throwing the `dataCorrupted` error.

### Impact
- Without this fix, iOS apps cannot update strings/content over the air and must rely on local JSON + app updates.
- With this fix, iOS achieves feature parity with Android SDK behavior.