### PR TITLE
Casting Issue for Swift 6+

### DIFF
--- a/Sources/Contentful/ArrayResponse.swift
+++ b/Sources/Contentful/ArrayResponse.swift
@@ -155,7 +155,7 @@ extension HomogeneousArrayResponse: Decodable {
             items = entries.compactMap { $0 as? ItemType }
 
             // Cache to enable link resolution.
-            decoder.linkResolver.cache(entryDecodables: items as! [EntryDecodable])
+            decoder.linkResolver.cache(entryDecodables: items.compactMap { $0 as? EntryDecodable })
         } else {
             // Since self's items are NOT of a custom (i.e. user-defined) type,
             // we can assume that they are of one of the known concrete types in this SDK.


### PR DESCRIPTION
Previously (Swift 5.x), Swift allowed force casting more liberally, even if the generic constraint didn’t prove it — the cast succeeded at runtime as long as the objects actually conformed.

Starting in Swift 6:

Existential casts like as! [SomeProtocol] now require the compiler to verify the generic type actually conforms

Existentials must be explicitly declared

**Many “accidental” casts that used to work in Swift 5 fail in Swift 6 with runtime errors**

In `HomogeneousArrayResponse`, `items` were being force casted into `[EntryDecodable]`. This worked fine before Swift 6, but now crashes in Swift 6. The compiler cannot prove that ItemType is EntryDecodable, even though your actual values _are_.

Swift’s new rules require the generic constraint to explicitly state so, and this change fixes that!

NOTE: I haven't run into any other issues yet, but with Swift 6 having breaking changes, and a lot of folks on Xcode 26 now, there may be more work here. I don't believe this is an issue using GraphQL, just the `contentful.swift` SDK. 