### PR TITLE
fix: allow nil fields on RichText Text node

### DIFF
--- a/Sources/Contentful/RichText.swift
+++ b/Sources/Contentful/RichText.swift
@@ -466,10 +466,17 @@ public struct Text: Node, Equatable {
     /// An array of the markup styles which should be applied to the text.
     public let marks: [Mark]
 
-    public init(value: String, marks: [Mark]) {
-        nodeType = .text
+    init(value: String, marks: [Mark]) {
+        self.nodeType = .text
         self.value = value
         self.marks = marks
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: JSONCodingKeys.self)
+        self.marks = try values.decodeIfPresent([Mark].self, forKey: JSONCodingKeys(stringValue: "marks")!) ?? []
+        self.value = try values.decodeIfPresent(String.self, forKey: JSONCodingKeys(stringValue: "value")!) ?? ""
+        self.nodeType = .text
     }
 
     /// THe markup styling which should be applied to the text.


### PR DESCRIPTION
`RichText` JSON deserialization fails if any `Text` node fields are missing, this PR updates the initializer to accommodate optional JSON fields. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>RichText JSON deserialization fails if any Text node fields are missing, this PR updates the initializer to accommodate optional JSON fields by adding a custom Decodable implementation that provides sensible defaults.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces a custom Decodable initializer for the Text struct in RichText.swift to handle missing JSON fields for value and marks.</li>

<li>Defaults marks to an empty array and value to an empty string when fields are absent.</li>

<li>Resolves failures in RichText JSON deserialization when Text node fields are nil.</li>

</ul>
</details>

</div>