### PR TITLE
docs: AI harness readiness — AGENTS.md, ARCHITECTURE.md, CONTRIBUTING.md, ADR [DX-1326]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,124 @@
+# AGENTS.md
+
+Orientation for coding agents working in `contentful.swift`, the Swift client
+for Contentful's Content Delivery and Content Preview APIs.
+
+Read this first, then [ARCHITECTURE.md](ARCHITECTURE.md) for the layout and
+[CONTRIBUTING.md](CONTRIBUTING.md) for the workflow.
+[ARCHITECTURE-BUILD-CONFIG.md](ARCHITECTURE-BUILD-CONFIG.md) is the deep
+reference on protocol design and the build system.
+
+## What this repo is
+
+- A read-only client. Delivery and Preview only — there is no Management API
+  surface here, so a request to "add a write/publish method" is out of scope for
+  this repo.
+- **Zero runtime dependencies.** `Package.swift` declares dependencies only for
+  the test target. Do not add a runtime dependency; it is a deliberate,
+  load-bearing constraint (app size, and installability through all three
+  package managers).
+- Multi-platform: iOS, macOS, tvOS, watchOS, from one source tree.
+- Distributed through CocoaPods, Carthage, **and** SwiftPM at the same time.
+
+## Default branch
+
+`master`, not `main`. Branch from and open pull requests against `master`.
+
+## Commands that actually exist
+
+Everything below is defined in the `Makefile`, `fastlane/Fastfile`, or
+`Scripts/`. Do not substitute conventional Swift commands for these.
+
+```bash
+make setup_env                 # Scripts/setup-env.sh: brew + bundle + carthage bootstrap
+make open                      # opens Contentful.xcworkspace
+make lint                      # swiftlint, then bundle exec pod lib lint Contentful.podspec
+make docs                      # Scripts/reference-docs.sh (jazzy)
+make release                   # Scripts/release.sh — maintainers only
+./Scripts/set-version.sh 5.5.16
+
+bundle exec fastlane test_ios
+bundle exec fastlane test_macos
+bundle exec fastlane test_tvos
+bundle exec fastlane build     # swift build only
+```
+
+Notes before you run anything:
+
+- Open `Contentful.xcworkspace`, never `Contentful.xcodeproj` on its own.
+- `make test` exists but pins the `iPhone X, OS=12.1` simulator destination,
+  which will not resolve on a modern toolchain. Use the fastlane lanes — those
+  are what CircleCI runs.
+- Ruby tools must be prefixed with `bundle exec`. `_ruby-version` is 3.0.5.
+- Tests replay recorded HTTP, so they need **no** Contentful credentials.
+- The build requires macOS and Xcode. On any other platform you can read and
+  edit, but you cannot verify — say so rather than claiming a green build.
+
+## Where to make changes
+
+| Change | File |
+| --- | --- |
+| Request/response plumbing, session, config | `Sources/Contentful/Client.swift`, `ClientConfiguration.swift` |
+| Fetch or sync surface | `Client+Fetch.swift`, `Client+Sync.swift` |
+| A new API path | `Endpoints.swift` (the `Endpoint` enum) |
+| Decoding, locale normalization | `Decodable.swift`, `JSONDecoderBuilder.swift` |
+| Link/relationship resolution | `LinkResolver.swift`, `DataCache.swift` |
+| Query building | `Query.swift`, `QueryOperation.swift`, `TypedQuery.swift` |
+| Image transformations | `Sources/Contentful/ImageOptions/ImageOptions.swift` |
+| iOS/tvOS/watchOS-only code | `Sources/Contentful/UIKit/` |
+| macOS-only code | `Sources/Contentful/AppKit/` |
+| Test models | `Tests/Helpers/Models/` (`Cat`, `Dog`, `City`) |
+
+## Constraints that will bite you
+
+- **A new source file must be added to all four framework targets** in
+  `Contentful.xcodeproj`, not just SwiftPM. SwiftPM globs `Sources/`; Xcode does
+  not. A file that only builds under `swift build` will fail CI's iOS, macOS,
+  and tvOS jobs.
+- **CocoaPods needs the file to match a `source_files` glob** in
+  `Contentful.podspec`. The globs are one level deep per directory
+  (`Sources/Contentful/*.swift`, `Sources/Contentful/UIKit/*.swift`, etc.), so a
+  new subdirectory needs a new glob or subspec or it silently ships empty.
+- **The version number lives in two files.** `Config.xcconfig` and `.env` must
+  match. Always change them with `./Scripts/set-version.sh`, never by hand.
+- **Deployment targets in `Contentful.podspec`** (iOS 12.0, macOS 10.13,
+  tvOS 12.0, watchOS 4.0) — raising any of them is a breaking change requiring a
+  major version bump.
+- **Link resolution is deferred.** Linked fields on an `EntryDecodable` are
+  assigned inside a `resolveLink(forKey:decoder:)` closure that runs after the
+  whole response is decoded, so do not expect a linked value to be available
+  inside `init(from:)`.
+- **Do not reintroduce Nimble** or another matcher framework. It has been
+  removed twice; assertions are plain `XCTest` on purpose. See
+  [ARCHITECTURE-BUILD-CONFIG.md](ARCHITECTURE-BUILD-CONFIG.md#dependencies-and-testing).
+- **Test dependencies point at Contentful forks** of DVR and OHHTTPStubs, in
+  both `Cartfile.private` and `Package.swift`. Do not "fix" them back to
+  upstream — see
+  [docs/ADRs/2026-08-25-vendor-forked-test-http-stubbing-dependencies.md](docs/ADRs/2026-08-25-vendor-forked-test-http-stubbing-dependencies.md).
+  If you change one manifest, change the other; they must stay in sync.
+- **`docs/` is generated output** from Jazzy, published to `gh-pages`. Do not
+  hand-edit it. `docs/ADRs/` is the one hand-written subtree.
+- **`.env` and `Config.xcconfig` are tracked** and contain only
+  `CONTENTFUL_SDK_VERSION`. Never add credentials to either.
+- SwiftLint (`.swiftlint.yml`) lints `Sources` only, with a 150-char line-length
+  warning and a number of rules deliberately disabled.
+- `RateLimitTests.swift` is present but its body is commented out; it asserts
+  nothing today. Do not treat it as coverage.
+
+## Conventions
+
+- Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`. Put the Jira key in
+  brackets when there is one, e.g. `fix: resolve decoding crash [DX-1234]`.
+- Every source file starts with the existing header comment block
+  (filename, module, author, copyright) — match it.
+- Public API carries doc comments; Jazzy publishes them.
+- Add a `CHANGELOG.md` entry for anything user-facing.
+- Review is owned by `@contentful/team-developer-experience`
+  (`.github/CODEOWNERS`, `catalog-info.yaml`).
+
+## Definition of done
+
+CircleCI must be green on `test-ios`, `test-macos`, `test-tvos`, and `build`.
+`build` runs `swift build`, so all three package-manager paths stay exercised —
+if you touched project structure, confirm the change lands in the Xcode targets,
+the podspec globs, and `Package.swift`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,167 @@
+# Architecture
+
+`contentful.swift` is the Swift client for Contentful's Content Delivery API
+(CDA) and Content Preview API (CPA). It is read-only — there is no management or
+write surface here — and it ships with **no runtime dependencies**, which keeps
+consumer app size down and keeps the SDK installable through CocoaPods,
+Carthage, and Swift Package Manager alike.
+
+This file is the map. For the long-form reference on the protocol design, the
+Xcode/Carthage build system, and the reasoning behind the distribution setup,
+see [ARCHITECTURE-BUILD-CONFIG.md](ARCHITECTURE-BUILD-CONFIG.md). Deliberate
+choices with lasting consequences are recorded in [docs/ADRs/](docs/ADRs/).
+
+## Repository layout
+
+```
+Sources/Contentful/          the SDK — one module, flat, plus three subfolders
+  UIKit/                     iOS / tvOS / watchOS extensions
+  AppKit/                    macOS extensions
+  ImageOptions/              image transformation API (a CocoaPods subspec)
+Tests/ContentfulTests/       24 test files
+  DVRRecordings/             recorded HTTP cassettes replayed by DVR
+  Fixtures/                  raw JSON fixtures
+Tests/Helpers/Models/        Cat, Dog, City — the EntryDecodable test models
+Supporting Files/            umbrella header + per-platform Info plists
+Scripts/                     setup-env, set-version, reference-docs, release
+  BuildPhases/swiftlint.sh   SwiftLint, invoked from the Xcode build phase
+Contentful.xcworkspace/      the entry point for local development
+fastlane/Fastfile            the lanes CircleCI runs
+docs/                        generated Jazzy site (published to gh-pages)
+docs/ADRs/                   architecture decision records
+```
+
+## Runtime shape
+
+The public surface is one module, `Contentful`, built around a single client
+type. There is no layered service/repository indirection — the client owns the
+`URLSession` and the decoding pipeline directly.
+
+- **`Client`** (`Client.swift`) is the entry point. It is `open`, holds a
+  `ClientConfiguration`, a `spaceId`, an `environmentId`, a `host`, and the
+  `URLSession`. Requests complete through
+  `ResultsHandler<T> = (Result<T, Error>) -> Void`.
+  `Client+Fetch.swift` and `Client+Sync.swift` split the fetch and
+  synchronization surfaces into extensions; `Client+UIKit.swift` and
+  `Client+AppKit.swift` add the platform-specific image fetching.
+- **`Endpoint`** (`Endpoints.swift`) enumerates the five API paths the SDK
+  talks to — `spaces` (the base path), `content_types`, `entries`, `assets`,
+  `locales`, and `sync`. Adding a new API surface starts here.
+- **Model types** map one-to-one to CDA resources: `Entry`, `Asset`,
+  `ContentType`, `Field`, `FieldType`, `Space`, `Locale`, `Link`, `Sys`,
+  `Location`, `Metadata`, `ArrayResponse`, `SyncSpace`, `RichText`.
+- **Decoding** goes through `Decodable.swift` and `JSONDecoderBuilder.swift`.
+  The client injects the space's `LocalizationContext` into the decoder builder
+  so that the `fields` dictionary of entries and assets is normalized against
+  the locale fallback chain before user code sees it. `Date.swift` and
+  `DateFormatterCache.swift` handle ISO-8601 parsing.
+- **Link resolution** is two-phase. `LinkResolver` registers a callback per
+  unresolved `Link` while decoding, backed by a `DataCache` keyed as
+  `<id>_<linktype>_`; once the whole response is decoded, the callbacks fire and
+  both caches are cleared. This is why a linked property on an
+  `EntryDecodable` is assigned inside a `resolveLink(forKey:decoder:)` closure
+  rather than returned from `init(from:)`.
+- **Querying** is in `Query.swift`, `QueryOperation.swift`, and
+  `TypedQuery.swift`. Types conforming to `FieldKeysQueryable` get compile-time
+  checked queries — `QueryOn<Cat>.where(field: .color, .equals("gray"))` becomes
+  `content_type=cat&fields.color=gray`.
+- **Persistence** is a delegate boundary, not an implementation. `Client` holds
+  an optional `persistenceIntegration`; the `PersistenceIntegration` protocol in
+  `Persistence.swift` receives create/update/delete messages during `sync`
+  calls. The CoreData implementation lives in a separate repository,
+  [contentful-persistence.swift](https://github.com/contentful/contentful-persistence.swift).
+  Setting the integration rebuilds the `URLSession` because its user-agent
+  header has to be regenerated.
+- **Logging** goes through `ContentfulLogger.swift`.
+
+The protocol hierarchy consumers actually implement — `Resource`,
+`FlatResource`, `AssetProtocol`, `EntryDecodable`, `FieldKeysQueryable` — is
+documented in detail in
+[ARCHITECTURE-BUILD-CONFIG.md](ARCHITECTURE-BUILD-CONFIG.md#sdk-architecture-and-important-protocols).
+
+## Multi-platform structure
+
+All four Cocoa platforms are supported from one source tree. Platform-specific
+code is guarded with `#if os(...)` and, where it needs its own file, split into
+`Sources/Contentful/UIKit/` and `Sources/Contentful/AppKit/`. Four shared Xcode
+schemes exist — `Contentful_iOS`, `Contentful_macOS`, `Contentful_tvOS`,
+`Contentful_watchOS` — and tests run against the first three; Apple ships no
+unit testing framework for watchOS.
+
+Minimum deployment targets are declared in `Contentful.podspec`: iOS 12.0,
+macOS 10.13, tvOS 12.0, watchOS 4.0. Raising any of them is a breaking change.
+
+## Build and dependency management
+
+Three package managers are supported simultaneously, and each one constrains the
+project differently:
+
+- **Xcode / Carthage** — `Contentful.xcworkspace` wraps
+  `Contentful.xcodeproj` and the playground, and nothing else. Carthage supplies
+  the *test* dependencies pinned in `Cartfile.private` /
+  `Cartfile.resolved`; CI resolves them with
+  `carthage update --use-xcframeworks`. Note that
+  `Scripts/setup-env.sh` still runs the older
+  `carthage bootstrap --use-submodules --no-build`, and the parts of
+  `ARCHITECTURE-BUILD-CONFIG.md` describing `Carthage/Checkouts` as
+  version-controlled submodules describe the pre-2024 setup — those submodules
+  and their workspace references were removed in `7d2399e`, and `.gitmodules` is
+  now empty.
+- **Swift Package Manager** — `Package.swift` (swift-tools-version 5.3)
+  declares the `Contentful` library target and a `ContentfulTests` test target
+  at `path: "Tests"`, with `Package.resolved` pinning the test dependencies.
+- **CocoaPods** — `Contentful.podspec` is a Ruby file that reads its version
+  from `.env` via the `dotenv` gem, declares per-platform `source_files`, and
+  exposes `ImageOptions` as a subspec.
+
+Both test-dependency manifests point at Contentful-maintained forks of DVR and
+OHHTTPStubs rather than upstream; see
+[docs/ADRs/2026-08-25-vendor-forked-test-http-stubbing-dependencies.md](docs/ADRs/2026-08-25-vendor-forked-test-http-stubbing-dependencies.md).
+
+The version number is duplicated in `Config.xcconfig` (read by the Xcode project
+and injected into the `X-Contentful-User-Agent` header) and `.env` (read by the
+podspec and sourced by the release and docs scripts). `Scripts/set-version.sh`
+writes both so they cannot drift.
+
+Ruby tooling is pinned through `Gemfile` / `Gemfile.lock` (`_ruby-version` is
+3.0.5) and covers cocoapods, jazzy, slather, xcpretty, and fastlane. Renovate
+(`renovate.json`, extending `contentful/renovate-config`) handles bumps.
+
+## Testing strategy
+
+Assertions are plain `XCTest`. Nimble was integrated, pruned, reintegrated, and
+pruned again — the standing guidance in
+[ARCHITECTURE-BUILD-CONFIG.md](ARCHITECTURE-BUILD-CONFIG.md#dependencies-and-testing)
+is not to bring it back, because third-party matcher frameworks kept breaking
+command-line builds for tvOS and macOS.
+
+Network traffic is stubbed, not live: DVR replays 17 recorded cassettes in
+`Tests/ContentfulTests/DVRRecordings/`, and OHHTTPStubs covers the one case that
+needs a hand-built response — `ErrorTests.swift` stubs
+`/spaces/cfexampleapi` to return a body the SDK cannot parse. That keeps the
+suite fast and immune to content drift in the Contentful spaces the recordings
+came from — and it means a normal test run needs no credentials.
+
+`Makefile` has an `integration_test` target that builds the `API_Coverage`
+configuration. `Scripts/integration-test.sh` still calls the Travis API and is
+not wired into the current CircleCI config.
+
+## CI and release
+
+CircleCI (`.circleci/config.yml`, macOS image with Xcode 15.4) runs four jobs on
+every pull request — `test-ios`, `test-macos`, `test-tvos`, and `build` — each
+installing Carthage, running `carthage update --use-xcframeworks`,
+`bundle install`, and then the matching `bundle exec fastlane` lane. The `build`
+lane shells out to `swift build` so the SPM path stays verified.
+`.github/workflows/codeql.yml` adds CodeQL scanning. SwiftLint skips itself in
+CI (`Scripts/BuildPhases/swiftlint.sh` exits early when `CIRCLECI` is set).
+
+`old-travis-config.yml` is the retired Travis configuration, kept for reference;
+parts of `ARCHITECTURE-BUILD-CONFIG.md` still describe that era. The move to
+CircleCI plus fastlane happened in `7d2399e`.
+
+Releases run from `master` via `make release` (`Scripts/release.sh`): tag, push
+to the CocoaPods trunk, build the XCFramework, regenerate the Jazzy docs onto
+`gh-pages`. The XCFramework zip is attached to the GitHub release by hand.
+Ownership is `group:team-developer-experience` (`catalog-info.yaml`,
+`.github/CODEOWNERS`); service tier 4.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,133 @@
+# Contributing to contentful.swift
+
+We appreciate any help on this repository. Bug reports, feature proposals, and
+pull requests are all welcome — see the [Reach out to us](README.md#reach-out-to-us)
+section of the README for where to raise which kind of issue.
+
+## Development and versioning
+
+Development should be done with Xcode as a strict requirement of the project is that iOS, macOS, tvOS, and watchOS stay supported. This, in turn, means that development will be done on a Mac, and it is therefore required that [homebrew](https://brew.sh/) is installed. The `make setup_env` command will install or update the necessary brew packages required to work on the contentful.swift project (note that it will not install homebrew for you).
+
+## Setting up your environment
+
+```bash
+make setup_env
+```
+
+`Scripts/setup-env.sh` (which `make setup_env` invokes) installs or upgrades
+`carthage` and `swiftlint` via Homebrew, runs `bundle install` for the Ruby
+tooling in the `Gemfile` (cocoapods, jazzy, slather, xcpretty, fastlane), and
+resolves the test dependencies with
+`carthage bootstrap --use-submodules --no-build`.
+
+The Ruby version this project is developed against is in `_ruby-version`
+(currently 3.0.5). Always prefix the Ruby-backed tools with `bundle exec` so you
+get the versions pinned in `Gemfile.lock` — for example
+`bundle exec pod trunk push`, not `pod trunk push`.
+
+Open the project through the workspace, never the bare `.xcodeproj`:
+
+```bash
+make open   # opens Contentful.xcworkspace
+```
+
+## Project layout
+
+- `Sources/Contentful/` — the SDK. Platform-specific code lives in
+  `Sources/Contentful/UIKit/` (iOS, tvOS, watchOS),
+  `Sources/Contentful/AppKit/` (macOS), and `Sources/Contentful/ImageOptions/`
+  (shipped as a CocoaPods subspec).
+- `Tests/ContentfulTests/` — the test suite, with stubbed HTTP responses in
+  `Tests/ContentfulTests/DVRRecordings/` and JSON fixtures in
+  `Tests/ContentfulTests/Fixtures/`.
+- `Tests/Helpers/Models/` — the `EntryDecodable` model types (`Cat`, `Dog`,
+  `City`) that the tests decode against.
+- `Scripts/` — environment setup, version bumping, docs generation, release.
+- `Supporting Files/` — the umbrella header and per-platform `Info-*.plist`
+  files for the four framework targets.
+
+## Running tests
+
+There are four shared schemes — `Contentful_iOS`, `Contentful_macOS`,
+`Contentful_tvOS`, `Contentful_watchOS` — and tests run against the first three
+(Apple ships no unit testing framework for watchOS).
+
+Locally, either run the scheme from Xcode or use the fastlane lanes that CI
+uses, which is the closest match to what the pipeline will do:
+
+```bash
+bundle exec fastlane test_ios
+bundle exec fastlane test_macos
+bundle exec fastlane test_tvos
+bundle exec fastlane build      # verifies `swift build` still works
+```
+
+The `make test` target also exists but pins an old simulator destination
+(`iPhone X, OS=12.1`); prefer the fastlane lanes unless you have that runtime
+installed.
+
+Most tests replay recorded HTTP traffic through DVR rather than hitting the
+Contentful APIs, so a normal test run needs no credentials. If you add a test
+that needs a new recording, commit the cassette alongside it.
+
+`make integration_test` builds the `API_Coverage` configuration and is driven by
+CI; `Scripts/integration-test.sh` still targets the old Travis API and is not
+wired into the current CircleCI config.
+
+## Linting
+
+```bash
+make lint    # swiftlint, then `bundle exec pod lib lint Contentful.podspec`
+```
+
+SwiftLint also runs as an Xcode build phase via
+`Scripts/BuildPhases/swiftlint.sh`, which skips itself when `CIRCLECI` is set.
+Rules live in `.swiftlint.yml`; it lints `Sources` only — `Tests`, `Carthage`,
+and `Contentful.playground` are excluded.
+
+## Commit messages and pull requests
+
+- Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
+  (`feat:`, `fix:`, `chore:`, `docs:`) — see `git log` for the house style.
+- Reference the Jira ticket in brackets when there is one, e.g.
+  `chore: set up Renovate for dependency updates [MEC-3447]`.
+- Open pull requests against `master`. `.github/CODEOWNERS` assigns review to
+  `@contentful/team-developer-experience`.
+- CircleCI runs `test-ios`, `test-macos`, `test-tvos`, and `build` on every
+  pull request; all four must be green.
+- Add a `CHANGELOG.md` entry for anything user-facing.
+- Dependency bumps arrive via Renovate (`renovate.json`).
+
+## Changing the SDK version
+
+The version lives in two files that must stay in sync — `Config.xcconfig`
+(consumed by the Xcode project and injected into the `X-Contentful-User-Agent`
+header) and `.env` (read by `Contentful.podspec` through the `dotenv` gem, and
+sourced by the release and docs scripts). Use the script rather than editing
+them by hand:
+
+```bash
+./Scripts/set-version.sh 5.5.16
+```
+
+Raising a minimum deployment target in `Contentful.podspec` is a breaking change
+and requires a major version bump.
+
+## Releasing
+
+Releases are run from `master` by a maintainer with CocoaPods trunk push rights:
+
+1. Bump the version with `./Scripts/set-version.sh`.
+2. Add the release notes to `CHANGELOG.md`.
+3. Run `make release` (`Scripts/release.sh`), which tags the version, pushes to
+   the CocoaPods trunk, builds the XCFramework, and regenerates the Jazzy
+   reference docs onto the `gh-pages` branch.
+4. Attach `Carthage/Build/Contentful.xcframework` (zipped) to the GitHub release
+   and copy the changelog entry into the release body.
+
+## Further reading
+
+[ARCHITECTURE.md](ARCHITECTURE.md) covers how the pieces fit together.
+[ARCHITECTURE-BUILD-CONFIG.md](ARCHITECTURE-BUILD-CONFIG.md) is the long-form
+reference on the protocol design, the build system, and the reasoning behind the
+distribution setup. Decision records are in [docs/ADRs/](docs/ADRs/).

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,5 +1,0 @@
-
-
-## Development and versioning
-Development should be done with Xcode as a strict requirement of the project is that iOS, macOS, tvOS, and watchOS stay supported. This, in turn, means that development will be done on a Mac, and it is therefore required that [homebrew](https://brew.sh/) is installed. The `make setup_env` command will install or update the necessary brew packages required to work on the contentful.swift project (note that it will not install homebrew for you).
-

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ It is recommended to use Swift 5.0, as older versions of the library will not ha
 
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?maxAge=31557600)](http://makeapullrequest.com)
 
-We appreciate any help on our repositories. For more details about how to contribute see our [Contributing.md](Contributing.md) document.
+We appreciate any help on our repositories. For more details about how to contribute see our [CONTRIBUTING.md](CONTRIBUTING.md) document.
 
 ## License
 

--- a/docs/ADRs/2026-08-25-vendor-forked-test-http-stubbing-dependencies.md
+++ b/docs/ADRs/2026-08-25-vendor-forked-test-http-stubbing-dependencies.md
@@ -1,0 +1,86 @@
+# Consume the test HTTP-stubbing dependencies from Contentful-maintained forks
+
+- **Date:** 2026-08-25 (record written); decision made 2024-08-16
+- **Status:** Accepted
+
+> This record was written on 2026-08-25 from the commit history. It documents an
+> existing decision rather than a new one. The commits, diffs, and manifest state
+> cited below are verifiable in this repository; where the original motivation
+> was not written down, that is stated explicitly rather than guessed at.
+
+## Context
+
+The SDK ships with no runtime dependencies, but its test suite needs two
+libraries to avoid hitting the Contentful APIs on every run:
+
+- **DVR** — records and replays HTTP traffic as JSON cassettes
+  (`Tests/ContentfulTests/DVRRecordings/`, 17 files).
+- **OHHTTPStubs** — hand-built responses for cases no recording can express;
+  used in `Tests/ContentfulTests/ErrorTests.swift` to return an unparsable body.
+
+Until August 2024 both came from upstream, and both were consumed as git
+submodules whose Xcode projects were pulled into `Contentful.xcworkspace`. Before
+`7d2399e`, `Cartfile.private` read:
+
+```
+github "venmo/DVR" ~> 2.1.0
+github "AliSoftware/OHHTTPStubs" ~> 8.0.0
+```
+
+## Decision
+
+Point both test dependencies at Contentful-maintained forks, and stop carrying
+them as workspace submodules.
+
+Evidence:
+
+- **`7d2399e` — "fix: tests (#410)", 2024-08-16.** Rewrites
+  `Cartfile.private` / `Cartfile.resolved` to
+  `mariuskatcontentful/DVR ~> 2.1.0` and
+  `mariuskatcontentful/OHHTTPStubs ~> 9.0.0`. The same commit deletes the
+  `Carthage/Checkouts/DVR` and `Carthage/Checkouts/OHHTTPStubs` submodules,
+  empties `.gitmodules`, drops their `FileRef`s from
+  `Contentful.xcworkspace/contents.xcworkspacedata`, reworks
+  `Contentful.xcodeproj/project.pbxproj` (299 lines), replaces the Travis
+  configuration with `.circleci/config.yml` plus fastlane lanes, and re-records
+  the `EntryTests` and `QueryTests` cassettes.
+- **`81cb107` — "feat: update Swift tools version and add dependencies (#418)",
+  2024-11-19.** Raises `Package.swift` to swift-tools-version 5.3 and adds the
+  same two forks as SwiftPM dependencies, plus a `ContentfulTests` test target,
+  so the SwiftPM path gains the stubbing libraries the Xcode path already had.
+- **Current state:** `Cartfile.resolved` pins
+  `mariuskatcontentful/OHHTTPStubs "9.1.0"`; `Package.resolved` pins the forks by
+  revision (`fb4f867…` for DVR, `1c5f7b4…` for OHHTTPStubs).
+
+The commit messages in `#410` are a long chain of `chore: update` /
+`chore: try new script` entries, and neither the commit body nor the manifests
+state which upstream limitation forced the fork. What is verifiable is that the
+fork switch, the submodule removal, the Xcode 15.4 CI migration, and the cassette
+re-recording all landed in one commit — i.e. the forks were adopted as part of
+getting the suite building and passing again on a newer toolchain, not as an
+independent dependency-policy change.
+
+## Consequences
+
+- Contentful owns the maintenance of both forks. If a toolchain bump breaks
+  stubbing again, the fix is made in the fork, not waited on upstream. This is
+  the same posture the repo already took toward test tooling when Nimble was
+  removed in favour of plain `XCTest`.
+- **The dependency is declared twice and must be kept in sync.** A change to
+  `Cartfile.private` / `Cartfile.resolved` has to be mirrored in `Package.swift`
+  / `Package.resolved` or the Xcode and SwiftPM test paths diverge. CircleCI runs
+  both (`test-*` lanes via Xcode, `build` via `swift build`), so a drift shows up
+  as a job failure rather than silently.
+- **The SwiftPM declarations track `.branch("master")`, not a version.** SwiftPM
+  therefore has no semantic-version constraint on the test dependencies;
+  `Package.resolved` is the only thing pinning a revision. Anyone re-resolving
+  will pick up whatever is on the fork's default branch.
+- Reverting to upstream is not a safe drive-by change: it would need the
+  stubbing behaviour re-verified across the iOS, macOS, and tvOS test jobs.
+  `AGENTS.md` and `CONTRIBUTING.md` flag this so the forks are not "corrected"
+  back by mistake.
+- Because the submodules are gone, a fresh clone no longer has the dependency
+  sources on disk, and `Scripts/setup-env.sh` — which still runs
+  `carthage bootstrap --use-submodules --no-build` — no longer matches what CI
+  does (`carthage update --use-xcframeworks`). The script has not been updated to
+  follow.

--- a/docs/ADRs/README.md
+++ b/docs/ADRs/README.md
@@ -1,0 +1,5 @@
+# Architecture Decision Records
+
+Decisions with lasting consequences for this repository, newest first.
+
+- [2026-08-25 — Consume the test HTTP-stubbing dependencies from Contentful-maintained forks](2026-08-25-vendor-forked-test-http-stubbing-dependencies.md) — DVR and OHHTTPStubs are taken from Contentful forks and no longer vendored as workspace submodules.


### PR DESCRIPTION
Closes the AI harness readiness controls for `contentful.swift` (DX-1326, parent DX-1296).

## Controls closed

All four:

| Control | File | Non-blank lines |
| --- | --- | --- |
| 1. `AGENTS.md` at root | `AGENTS.md` | 104 |
| 2. `ARCHITECTURE.md` at root | `ARCHITECTURE.md` | 142 |
| 3. `CONTRIBUTING.md` at root | `CONTRIBUTING.md` | 101 |
| 4. `.md` decision record under `docs/ADRs/` | `docs/ADRs/2026-08-25-vendor-forked-test-http-stubbing-dependencies.md` | 72 |

## Files

- `AGENTS.md` — new. Orientation for coding agents: what this repo is and is not (read-only Delivery/Preview client, zero runtime dependencies, four Cocoa platforms, three package managers), the commands that actually exist in the `Makefile` / `fastlane/Fastfile` / `Scripts/`, a table of where to make which change, and the constraints that break builds here.
- `ARCHITECTURE.md` — new. Repository layout, runtime shape (`Client`, the `Endpoint` enum, the decoder/localization pipeline, `LinkResolver`/`DataCache`, the `PersistenceIntegration` boundary), the multi-platform and multi-package-manager build setup, the DVR/OHHTTPStubs testing strategy, CI and release. It references the existing `ARCHITECTURE-BUILD-CONFIG.md` for the deep protocol/build reference rather than duplicating it.
- `CONTRIBUTING.md` — **renamed** from `Contributing.md` via `git mv` (two-step, so the case change is recorded). The original "Development and versioning" section is preserved verbatim; setup, project layout, test, lint, commit/PR, versioning, and release sections were added. Exactly one spelling is tracked — `git ls-files | grep -i contributing` returns only `CONTRIBUTING.md`.
- `docs/ADRs/2026-08-25-vendor-forked-test-http-stubbing-dependencies.md` — new. See disclosure below.
- `docs/ADRs/README.md` — new. One-line index of the record.
- `README.md` — one-line change: the "Get involved" link now points at `CONTRIBUTING.md` so it does not break on case-sensitive checkouts.

## ADR disclosure

The record documents a decision the repo already made — taking DVR and OHHTTPStubs from `mariuskatcontentful/` forks instead of `venmo/DVR` and `AliSoftware/OHHTTPStubs`, and dropping them as `Carthage/Checkouts` submodules in the workspace. It is evidenced by:

- `7d2399e` ("fix: tests (#410)", 2024-08-16) — rewrites `Cartfile.private` / `Cartfile.resolved` to the forks, deletes both submodules, empties `.gitmodules`, removes their workspace `FileRef`s, and replaces Travis with CircleCI + fastlane.
- `81cb107` ("feat: update Swift tools version and add dependencies (#418)", 2024-11-19) — adds the same forks to `Package.swift` for the SwiftPM path.

**It is a reconstruction, and says so in a blockquote at the top.** The commits do not record which upstream limitation forced the fork, so the ADR states what is verifiable and explicitly declines to guess at the motivation.

## Things worth a maintainer's eye (documented, not changed)

- `Package.swift` declares both test dependencies as `.branch("master")` — no semantic-version constraint; `Package.resolved` is the only pin.
- `Scripts/setup-env.sh` still runs `carthage bootstrap --use-submodules --no-build`, which no longer matches CI's `carthage update --use-xcframeworks`; the submodules it refers to were removed in `7d2399e`.
- `make test` pins the `iPhone X, OS=12.1` simulator destination and will not resolve on a modern toolchain. The fastlane lanes are what CI uses.
- `Tests/ContentfulTests/RateLimitTests.swift` has a commented-out body and asserts nothing today.
- Parts of `ARCHITECTURE-BUILD-CONFIG.md` describe the pre-2024 Travis/submodule era. `ARCHITECTURE.md` flags this inline rather than editing that file.

Docs only — no source, build, or dependency changes. Per the rollout instructions no installs, builds, or test suites were run locally.